### PR TITLE
Added compile flags for gpu-simulator and traces-processing Makefiles

### DIFF
--- a/gpu-simulator/Makefile
+++ b/gpu-simulator/Makefile
@@ -37,9 +37,9 @@ else
 endif
 
 ifeq ($(DEBUG),1)
-	CXXFLAGS = -Wall -O0 -g3 -fPIC
+	CXXFLAGS = -Wall -O0 -g3 -fPIC -std=c++11
 else
-	CXXFLAGS = -Wall -O3 -g3 -fPIC
+	CXXFLAGS = -Wall -O3 -g3 -fPIC -std=c++11
 endif
 
 all: $(BIN_DIR)/accel-sim.out

--- a/gpu-simulator/trace-driven/Makefile
+++ b/gpu-simulator/trace-driven/Makefile
@@ -45,7 +45,7 @@ else
 	CXXFLAGS += 
 endif
 
-OPTFLAGS += -g3 -fPIC
+OPTFLAGS += -g3 -fPIC -std=c++11
 
 SRCS = $(shell ls *.cc)
 EXCLUDES = 

--- a/util/tracer_nvbit/tracer_tool/traces-processing/Makefile
+++ b/util/tracer_nvbit/tracer_tool/traces-processing/Makefile
@@ -1,7 +1,7 @@
 TARGET := post-traces-processing
 
 $(TARGET): post-traces-processing.cpp
-	g++ -o $@ $^
+	g++ -std=c++11 -o $@ $^
 
 run: $(TARGET)
 	./$(TARGET)


### PR DESCRIPTION
Some Makefiles were missing the `std=c++11` flag.