### PR TITLE
Renaming Turing_RTX2060 to SM75_RTX2060 

### DIFF
--- a/util/job_launching/configs/define-standard-cfgs.yml
+++ b/util/job_launching/configs/define-standard-cfgs.yml
@@ -14,7 +14,7 @@ TITANK:
 
 #Turing
 RTX2060:
-    base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/Turing_RTX2060/gpgpusim.config"
+    base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM75_RTX2060/gpgpusim.config"
 
 # Volta
 TITANV:

--- a/util/job_launching/stats/example_stats.yml
+++ b/util/job_launching/stats/example_stats.yml
@@ -30,7 +30,7 @@ collect_aggregate:
 collect_abs:
     - 'gpu_ipc\s*=\s*(.*)'
     - 'gpu_occupancy\s*=\s*(.*)%'
-    - 'L2_BW\s*=\s*(.*)+GB\/Sec'
+    - 'L2_BW\s*=\s*(.*)\s*GB\/Sec'
 
 # These stats are rates that aggregate - but cannot be diff'd
 # Only valid as a snapshot and most useful for the final kernel launch


### PR DESCRIPTION
to be consistent with the config name in GPGPUSIM