### PR TITLE
Fixing a double free issue with GCC > 9 in optimized mode

### DIFF
--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -86,7 +86,7 @@ trace_kernel_info_t::trace_kernel_info_t(dim3 gridDim, dim3 blockDim,
   }
 }
 
-bool trace_kernel_info_t::get_next_threadblock_traces(
+void trace_kernel_info_t::get_next_threadblock_traces(
     std::vector<std::vector<inst_trace_t> *> threadblock_traces) {
   m_parser->get_next_threadblock_traces(
       threadblock_traces, m_kernel_trace_info->trace_verion);

--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -88,14 +88,8 @@ trace_kernel_info_t::trace_kernel_info_t(dim3 gridDim, dim3 blockDim,
 
 bool trace_kernel_info_t::get_next_threadblock_traces(
     std::vector<std::vector<inst_trace_t> *> threadblock_traces) {
-  for (unsigned i = 0; i < threadblock_traces.size(); ++i) {
-    threadblock_traces[i]->clear();
-  }
-
-  bool success = m_parser->get_next_threadblock_traces(
+  m_parser->get_next_threadblock_traces(
       threadblock_traces, m_kernel_trace_info->trace_verion);
-
-  return success;
 }
 
 bool trace_warp_inst_t::parse_from_trace_struct(

--- a/gpu-simulator/trace-driven/trace_driven.h
+++ b/gpu-simulator/trace-driven/trace_driven.h
@@ -60,7 +60,7 @@ public:
                       trace_parser *parser, class trace_config *config,
                       kernel_trace_t *kernel_trace_info);
 
-  bool get_next_threadblock_traces(
+  void get_next_threadblock_traces(
       std::vector<std::vector<inst_trace_t> *> threadblock_traces);
 
 private:

--- a/gpu-simulator/trace-driven/trace_driven.h
+++ b/gpu-simulator/trace-driven/trace_driven.h
@@ -111,7 +111,7 @@ public:
   bool trace_done();
   address_type get_start_trace_pc();
   virtual address_type get_pc();
-  trace_warp_inst_t *set_kernel(trace_kernel_info_t *kernel_info) {
+  void set_kernel(trace_kernel_info_t *kernel_info) {
     m_kernel_info = kernel_info;
   }
 

--- a/gpu-simulator/trace-parser/trace_parser.cc
+++ b/gpu-simulator/trace-parser/trace_parser.cc
@@ -357,7 +357,7 @@ void trace_parser::kernel_finalizer() {
     ifs.close();
 }
 
-bool trace_parser::get_next_threadblock_traces(
+void trace_parser::get_next_threadblock_traces(
     std::vector<std::vector<inst_trace_t> *> threadblock_traces,
     unsigned trace_version) {
   for (unsigned i = 0; i < threadblock_traces.size(); ++i) {
@@ -417,6 +417,4 @@ bool trace_parser::get_next_threadblock_traces(
       }
     }
   }
-
-  return true;
 }


### PR DESCRIPTION
This pull request is a fix for issues [#32](https://github.com/accel-sim/accel-sim-framework/issues/32)  and [#49](https://github.com/accel-sim/accel-sim-framework/issues/49). With GCC > 9 the simulator crashes in [trace_driven.cc](https://github.com/accel-sim/accel-sim-framework/blob/release/gpu-simulator/trace-driven/trace_driven.cc). The bug can be bypassed with temporarily removing `-O3` in [trace-driven/Makefile](https://github.com/accel-sim/accel-sim-framework/blob/release/gpu-simulator/trace-driven/Makefile#L43). This function is supposed to return a pointer but it doesn't return anything indeed. Changing that to `void` fixes the runtime crash.

Additionally, by looking at `get_next_threadblock_traces()` there are unnecessary statements and return types:
- The `clear()` is redundant because that is done in [trace_parser::get_next_threadblock_traces()](https://github.com/accel-sim/accel-sim-framework/blob/release/gpu-simulator/trace-parser/trace_parser.cc#L363). 
- [trace_parser::get_next_threadblock_traces()](https://github.com/accel-sim/accel-sim-framework/blob/release/gpu-simulator/trace-parser/trace_parser.cc#L363) always return true. So what is the need to return a boolean value?
- [trace_kernel_info_t::get_next_threadblock_traces()](https://github.com/accel-sim/accel-sim-framework/blob/release/gpu-simulator/trace-driven/trace_driven.cc#L89) also returns a boolean value which is not clear why because [trace_kernel.get_next_threadblock_traces(threadblock_traces);](https://github.com/accel-sim/accel-sim-framework/blob/release/gpu-simulator/trace-driven/trace_driven.cc#L482) doesn't use that.