### PR TITLE
Fixed FCM and VADD opcodes for Pascal traces

### DIFF
--- a/gpu-simulator/ISA_Def/pascal_opcode.h
+++ b/gpu-simulator/ISA_Def/pascal_opcode.h
@@ -31,6 +31,7 @@ static const std::unordered_map<std::string, OpcodeChar> Pascal_OpcodeMap = {
     {"FSETP", OpcodeChar(OP_FSETP, SP_OP)},
     {"FSWZADD", OpcodeChar(OP_FSWZADD, SP_OP)},
     {"RRO", OpcodeChar(OP_RRO, SP_OP)},
+    {"FCMP", OpcodeChar(OP_FCMP, SP_OP)},
 
     // SFU
     {"MUFU", OpcodeChar(OP_MUFU, SFU_OP)},
@@ -78,6 +79,7 @@ static const std::unordered_map<std::string, OpcodeChar> Pascal_OpcodeMap = {
     {"SHR", OpcodeChar(OP_SHR, INTP_OP)},
     {"VABSDIFF", OpcodeChar(OP_VABSDIFF, INTP_OP)},
     {"VABSDIFF4", OpcodeChar(OP_VABSDIFF4, INTP_OP)},
+    {"VADD", OpcodeChar(OP_VADD, INTP_OP)},
     {"BFE", OpcodeChar(OP_BFE, INTP_OP)},
     {"BFI", OpcodeChar(OP_BFI, INTP_OP)},
     {"ICMP", OpcodeChar(OP_ICMP, INTP_OP)},

--- a/gpu-simulator/ISA_Def/trace_opcode.h
+++ b/gpu-simulator/ISA_Def/trace_opcode.h
@@ -62,6 +62,7 @@ enum TraceInstrOpcode {
   OP_SHR,
   OP_VABSDIFF,
   OP_VABSDIFF4,
+  OP_VADD,
   OP_F2F,
   OP_F2I,
   OP_I2F,


### PR DESCRIPTION
This PR contains two instructions that are necessary in order to use properly the traces of Rodinia 3.1 and Deepbench for Pascal.