### PR TITLE
version string should include gpgpusim version

### DIFF
--- a/util/job_launching/get_stats.py
+++ b/util/job_launching/get_stats.py
@@ -186,7 +186,7 @@ for idx, app_and_args in enumerate(apps_and_args):
 
         if config + app_and_args in specific_jobIds:
             jobId,jobname = specific_jobIds[ config + app_and_args ]
-            torque_submname = re.sub(r".*\.([^\s]*-commit-.*)", r"\1", jobname)
+            torque_submname = re.sub(r".*\.([^\s]*-commit-.*-commit-.*)", r"\1", jobname)
             outfile = os.path.join(output_dir, exes_and_args[idx].replace("/", "-") + "." +\
                torque_submname + "." + "o" + jobId)
         else:

--- a/util/job_launching/job_status.py
+++ b/util/job_launching/job_status.py
@@ -311,7 +311,7 @@ for logfile in parsed_logfiles:
                 continue
 
             num_jobs += 1
-            torquefile_base = re.sub(r".*\.([^\s]*-commit.*)", r"\1", jobname)
+            torquefile_base = re.sub(r".*\.([^\s]*-commit-.*-commit-.*)", r"\1", jobname)
             errfile = os.path.join(output_dir, os.path.basename(app) + "-" + args + "." + \
                 torquefile_base + "." + "e" + jobId)
             outfile = os.path.join(output_dir, os.path.basename(app) + "-" + args + "." + \

--- a/util/job_launching/run_simulations.py
+++ b/util/job_launching/run_simulations.py
@@ -46,8 +46,8 @@ import common
 this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
 # This function will pull the SO name out of the shared object,
 # which will have current GIT commit number attatched.
-def extract_version( exec_path ):
-    if options.trace_dir == "":
+def extract_version( exec_path, simulator):
+    if simulator == "gpgpusim":
         regex_base = "gpgpu-sim_git-commit"
     else:
         regex_base = "accelsim-commit"
@@ -356,7 +356,11 @@ else:
     this_directory )
     simulator_path = os.path.join( options.simulator_dir, "accel-sim.out" )
 
-version_string = extract_version( simulator_path )
+if options.trace_dir == "":
+    version_string = extract_version( simulator_path, "gpgpusim")
+else:
+    gpgpusim_path = os.path.join( os.getenv("GPGPUSIM_ROOT"), "lib", os.getenv("GPGPUSIM_CONFIG"), "libcudart.so")
+    version_string = extract_version(simulator_path, "accelsim") + extract_version(gpgpusim_path, "gpgpusim")
 running_sim_dir = os.path.join( options.run_directory, "gpgpu-sim-builds", version_string )
 if not os.path.exists( running_sim_dir ):
     # In the very rare case that concurrent builds try to make the directory at the same time


### PR DESCRIPTION
We should only be reusing accelsim.out files if the accelsim AND gpgpu-sim commit hashes match. This fixes reusing old builds after you've made changes to gpgpusim but not accelsim (which is quite common).