### PR TITLE
Add SASS <-> cuda kernel line number support to tracer

### DIFF
--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -122,6 +122,7 @@ void trace_kernel_info_t::get_next_threadblock_traces(
     std::vector<std::vector<inst_trace_t> *> threadblock_traces) {
   m_parser->get_next_threadblock_traces(threadblock_traces,
                                         m_kernel_trace_info->trace_verion,
+                                        m_kernel_trace_info->enable_lineinfo,
                                         m_kernel_trace_info->ifs);
 }
 

--- a/gpu-simulator/trace-parser/trace_parser.cc
+++ b/gpu-simulator/trace-parser/trace_parser.cc
@@ -125,7 +125,8 @@ void inst_memadd_info_t::base_delta_decompress(
 }
 
 bool inst_trace_t::parse_from_string(std::string trace,
-                                     unsigned trace_version) {
+                                     unsigned trace_version,
+                                     unsigned enable_lineinfo) {
   std::stringstream ss;
   ss.str(trace);
 
@@ -140,6 +141,9 @@ bool inst_trace_t::parse_from_string(std::string trace,
 
     ss >> std::dec >> threadblock_x >> threadblock_y >> threadblock_z >>
         warpid_tb;
+  }
+  if (enable_lineinfo) {
+    ss >> std::dec >> line_num;
   }
 
   ss >> std::hex >> m_pc;
@@ -273,6 +277,7 @@ void trace_parser::parse_memcpy_info(const std::string &memcpy_command,
 kernel_trace_t *trace_parser::parse_kernel_info(
     const std::string &kerneltraces_filepath) {
   kernel_trace_t *kernel_info = new kernel_trace_t;
+  kernel_info->enable_lineinfo = 0; // default disabled
   kernel_info->ifs = new std::ifstream;
   std::ifstream *ifs = kernel_info->ifs;
   ifs->open(kerneltraces_filepath.c_str());
@@ -323,6 +328,9 @@ kernel_trace_t *trace_parser::parse_kernel_info(
       } else if (string1 == "binary" && string2 == "version") {
         sscanf(line.c_str(), "-binary version = %d",
                &kernel_info->binary_verion);
+      } else if (string1 == "enable" && string2 == "lineinfo") {
+        sscanf(line.c_str(), "-enable lineinfo = %d",
+               &kernel_info->enable_lineinfo);
       } else if (string1 == "nvbit" && string2 == "version") {
         const size_t equal_idx = line.find('=');
         kernel_info->nvbit_verion = line.substr(equal_idx + 1);
@@ -360,7 +368,7 @@ void trace_parser::kernel_finalizer(kernel_trace_t *trace_info) {
 
 void trace_parser::get_next_threadblock_traces(
     std::vector<std::vector<inst_trace_t> *> threadblock_traces,
-    unsigned trace_version, std::ifstream *ifs) {
+    unsigned trace_version, unsigned enable_lineinfo, std::ifstream *ifs) {
   for (unsigned i = 0; i < threadblock_traces.size(); ++i) {
     threadblock_traces[i]->clear();
   }
@@ -413,7 +421,7 @@ void trace_parser::get_next_threadblock_traces(
         assert(start_of_tb_stream_found);
         threadblock_traces[warp_id]
             ->at(inst_count)
-            .parse_from_string(line, trace_version);
+            .parse_from_string(line, trace_version, enable_lineinfo);
         inst_count++;
       }
     }

--- a/gpu-simulator/trace-parser/trace_parser.h
+++ b/gpu-simulator/trace-parser/trace_parser.h
@@ -49,6 +49,7 @@ struct inst_trace_t {
   inst_trace_t();
   inst_trace_t(const inst_trace_t &b);
 
+  unsigned line_num;
   unsigned m_pc;
   unsigned mask;
   unsigned reg_dsts_num;
@@ -58,7 +59,8 @@ struct inst_trace_t {
   unsigned reg_src[MAX_SRC];
   inst_memadd_info_t *memadd_info;
 
-  bool parse_from_string(std::string trace, unsigned tracer_version);
+  bool parse_from_string(std::string trace, unsigned tracer_version,
+                         unsigned enable_lineinfo);
 
   bool check_opcode_contain(const std::vector<std::string> &opcode,
                             std::string param) const;
@@ -86,6 +88,7 @@ struct kernel_trace_t {
   unsigned nregs;
   unsigned long cuda_stream_id;
   unsigned binary_verion;
+  unsigned enable_lineinfo;
   unsigned trace_verion;
   std::string nvbit_verion;
   unsigned long long shmem_base_addr;
@@ -107,7 +110,7 @@ class trace_parser {
 
   void get_next_threadblock_traces(
       std::vector<std::vector<inst_trace_t> *> threadblock_traces,
-      unsigned trace_version, std::ifstream *ifs);
+      unsigned trace_version, unsigned enable_lineinfo, std::ifstream *ifs);
 
   void kernel_finalizer(kernel_trace_t *trace_info);
 

--- a/util/tracer_nvbit/README.md
+++ b/util/tracer_nvbit/README.md
@@ -68,9 +68,13 @@
 * Adding line numbers from source code:
 
     This feature can be used to see which SASS instructions were generated from which lines of kernel source code. By default it is disabled.
-    To enable source code line numbers compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags. Then set the following environment variable:
+    To enable source code line numbers compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags and set the `TRACE_LINEINFO=1`. For example:
     ```bash
     export TRACE_LINEINFO=1
+
+    # Rebuild application suite, the above flag will turn on the nvcc -lineinfo flag for you
+    source ./gpu-app-collection/src/setup_environment  
+    make -j -C ./gpu-app-collection/src rodinia_2.0-ft  
     ```
 
 * Traces format:

--- a/util/tracer_nvbit/README.md
+++ b/util/tracer_nvbit/README.md
@@ -60,9 +60,16 @@
     ```
     In this case, the tracer will trace nothing. However, it will still list kernels name and ids in stats.csv file. So, check the stats.csv file and see the exact kernel Ids you want to trace. This feature is very important if your application generates large traces, and you want to skip some kernels and trace specific important kernels. 
 
-    As an alternative to the method described above, you can wrap the region you want to trace with `cudaProfileStart()` and `cudaProfilerStop()` calls then set the following environment variable to trace only within that region. Note: setting `ACTIVE_FROM_START` to zero disables the effects of the `DYNAMIC_KERNEL_LIMIT_START/STOP` variables.
+    As an alternative to the method described above, you can wrap the region you want to trace with `cudaProfilerStart()` and `cudaProfilerStop()` calls then set the following environment variable to trace only within that region. Note: setting `ACTIVE_FROM_START` to zero disables the effects of the `DYNAMIC_KERNEL_LIMIT_START/STOP` variables.
     ```bash
     export ACTIVE_FROM_START=0
+    ```
+
+* Adding line numbers from source code:
+    This feature can be used to see which SASS instructions where generated from which lines of kernel source code. By default it is disabled.
+    To enable source code line numbers to the tracer compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags. Then set the following environment variable:
+    ```bash
+    export TRACE_LINEINFO=1
     ```
 
 * Traces format:
@@ -70,7 +77,7 @@
     The instruction format contains the following columns. Any column that is NOT contained in brackets [] must exist in any instruction format, so any instruction should have at least 10 column entries as reported below. 
     
     ```bash
-    #traces format = threadblock_x threadblock_y threadblock_z warpid_tb PC mask dest_num [reg_dests] opcode src_num [reg_srcs] mem_width [adrrescompress?] [mem_addresses]
+    #traces format = [line_num] PC mask dest_num [reg_dests] opcode src_num [reg_srcs] mem_width [adrrescompress?] [mem_addresses]
     ```
     
     The other columns that are in brackets [] may or may not exist based on the instruction characteristics, for example:

--- a/util/tracer_nvbit/README.md
+++ b/util/tracer_nvbit/README.md
@@ -67,8 +67,8 @@
 
 * Adding line numbers from source code:
 
-    This feature can be used to see which SASS instructions where generated from which lines of kernel source code. By default it is disabled.
-    To enable source code line numbers to the tracer compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags. Then set the following environment variable:
+    This feature can be used to see which SASS instructions were generated from which lines of kernel source code. By default it is disabled.
+    To enable source code line numbers compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags. Then set the following environment variable:
     ```bash
     export TRACE_LINEINFO=1
     ```

--- a/util/tracer_nvbit/README.md
+++ b/util/tracer_nvbit/README.md
@@ -68,11 +68,11 @@
 * Adding line numbers from source code:
 
     This feature can be used to see which SASS instructions were generated from which lines of kernel source code. By default it is disabled.
-    To enable source code line numbers compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags and set the `TRACE_LINEINFO=1`. For example:
+    To enable source code line numbers compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags and set the environment variable `TRACE_LINEINFO=1`. For example:
     ```bash
     export TRACE_LINEINFO=1
 
-    # Rebuild application suite, the above flag will turn on the nvcc -lineinfo flag for you
+    # Rebuild application suite, TRACE_LINEINFO=1 will turn on the nvcc -lineinfo flag for you
     source ./gpu-app-collection/src/setup_environment  
     make -j -C ./gpu-app-collection/src rodinia_2.0-ft  
     ```

--- a/util/tracer_nvbit/README.md
+++ b/util/tracer_nvbit/README.md
@@ -7,7 +7,7 @@
     # compile the tools
     ./make
     ```
-* To generate traces for benchamrk suite, run the following command:
+* To generate traces for benchamark suite, run the following command:
     ```bash
     # example: to run the tracer on hardware device 0 for rodinia workloads
     ./run_hw_trace.py -B rodinia-3.1 -D 0
@@ -66,6 +66,7 @@
     ```
 
 * Adding line numbers from source code:
+
     This feature can be used to see which SASS instructions where generated from which lines of kernel source code. By default it is disabled.
     To enable source code line numbers to the tracer compile your target benchmark applications with `-lineinfo` or `--generate-line-info` nvcc flags. Then set the following environment variable:
     ```bash

--- a/util/tracer_nvbit/tracer_tool/common.h
+++ b/util/tracer_nvbit/tracer_tool/common.h
@@ -20,6 +20,7 @@ typedef struct {
   int sm_id;
   int opcode_id;
   uint64_t addrs[32];
+  uint32_t line_num;
   uint32_t vpc;
   bool is_mem;
   int32_t GPRDst;

--- a/util/tracer_nvbit/tracer_tool/inject_funcs.cu
+++ b/util/tracer_nvbit/tracer_tool/inject_funcs.cu
@@ -22,7 +22,7 @@ extern "C" __device__ __noinline__ void instrument_inst(
     int32_t width, int32_t desReg, int32_t srcReg1, int32_t srcReg2,
     int32_t srcReg3, int32_t srcReg4, int32_t srcReg5, int32_t srcNum,
     uint64_t pchannel_dev, uint64_t ptotal_dynamic_instr_counter,
-    uint64_t preported_dynamic_instr_counter, uint64_t pstop_report) {
+    uint64_t preported_dynamic_instr_counter, uint64_t pstop_report, uint32_t line_num) {
 
   const int active_mask = __ballot_sync(__activemask(), 1);
   const int predicate_mask = __ballot_sync(__activemask(), pred);
@@ -52,6 +52,7 @@ extern "C" __device__ __noinline__ void instrument_inst(
   int4 cta = get_ctaid();
   int uniqe_threadId = threadIdx.z * blockDim.y * blockDim.x +
                        threadIdx.y * blockDim.x + threadIdx.x;
+  ma.line_num = line_num;
   ma.warpid_tb = uniqe_threadId / 32;
 
   ma.cta_id_x = cta.x;

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -28,7 +28,7 @@
 /* contains definition of the inst_trace_t structure */
 #include "common.h"
 
-#define TRACER_VERSION "3"
+#define TRACER_VERSION "4"
 
 /* Channel used to communicate from GPU to CPU receiving thread */
 #define CHANNEL_SIZE (1l << 20)
@@ -52,6 +52,7 @@ int enable_compress = 1;
 int print_core_id = 0;
 int exclude_pred_off = 1;
 int active_from_start = 1;
+int lineinfo = 0;
 /* used to select region of interest when active from start is 0 */
 bool active_region = true;
 
@@ -84,6 +85,9 @@ void nvbit_at_init() {
               "End of the instruction interval where to apply instrumentation");
   GET_VAR_INT(exclude_pred_off, "EXCLUDE_PRED_OFF", 1,
               "Exclude predicated off instruction from count");
+  GET_VAR_INT(lineinfo, "TRACE_LINEINFO", 0,
+              "Include source code line info at the start of each traced line. "
+              "The target binary must be compiled with -lineinfo or --generate-line-info");
   GET_VAR_INT(dynamic_kernel_limit_end, "DYNAMIC_KERNEL_LIMIT_END", 0,
               "Limit of the number kernel to be printed, 0 means no limit");
   GET_VAR_INT(dynamic_kernel_limit_start, "DYNAMIC_KERNEL_LIMIT_START", 0,
@@ -138,6 +142,7 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
     uint32_t cnt = 0;
     /* iterate on all the static instructions in the function */
     for (auto instr : instrs) {
+      uint32_t line_num = 0;
 
       if (cnt < instr_begin_interval || cnt >= instr_end_interval) {
         cnt++;
@@ -146,6 +151,11 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
 
       if (verbose) {
         instr->printDecoded();
+      }
+
+      if(lineinfo) {
+        char *file_name, *dir_name;
+        nvbit_get_line_info(ctx, func, instr->getOffset(), &file_name, &dir_name, &line_num);
       }
 
       if (opcode_to_id_map.find(instr->getOpcode()) == opcode_to_id_map.end()) {
@@ -221,7 +231,6 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           nvbit_add_call_arg_const_val32(instr, -1);
         }
         nvbit_add_call_arg_const_val32(instr, srcNum);
-       
         /* add pointer to channel_dev and other counters*/
         nvbit_add_call_arg_const_val64(instr, (uint64_t)&channel_dev);
         nvbit_add_call_arg_const_val64(instr,
@@ -229,6 +238,8 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
         nvbit_add_call_arg_const_val64(instr,
                                       (uint64_t)&reported_dynamic_instr_counter);
         nvbit_add_call_arg_const_val64(instr, (uint64_t)&stop_report);
+        /* Add Source code line number for current instr */
+        nvbit_add_call_arg_const_val32(instr, (int)line_num);
 
       } while (mem_oper_idx > 0);
 
@@ -382,11 +393,11 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
                 (uint64_t)nvbit_get_local_mem_base_addr(ctx));
         fprintf(resultsFile, "-nvbit version = %s\n", NVBIT_VERSION);
         fprintf(resultsFile, "-accelsim tracer version = %s\n", TRACER_VERSION);
+        fprintf(resultsFile,  "-enable lineinfo = %d\n", lineinfo);
         fprintf(resultsFile, "\n");
 
         fprintf(resultsFile,
-                "#traces format = threadblock_x threadblock_y threadblock_z "
-                "warpid_tb PC mask dest_num [reg_dests] opcode src_num "
+                "#traces format = [line_num] PC mask dest_num [reg_dests] opcode src_num "
                 "[reg_srcs] mem_width [adrrescompress?] [mem_addresses]\n");
         fprintf(resultsFile, "\n");
       }
@@ -581,6 +592,9 @@ void *recv_thread_fun(void *) {
         if (print_core_id) {
           fprintf(resultsFile, "%d ", ma->sm_id);
           fprintf(resultsFile, "%d ", ma->warpid_sm);
+        }
+        if(lineinfo){
+          fprintf(resultsFile, "%d ", ma->line_num);
         }
         fprintf(resultsFile, "%04x ", ma->vpc); // Print the virtual PC
         fprintf(resultsFile, "%08x ", ma->active_mask & ma->predicate_mask);

--- a/util/tracer_nvbit/tracer_tool/traces-processing/post-traces-processing.cpp
+++ b/util/tracer_nvbit/tracer_tool/traces-processing/post-traces-processing.cpp
@@ -98,6 +98,7 @@ void group_per_block(const char *filepath) {
   vector<threadblock_info> insts;
   unsigned grid_dim_x, grid_dim_y, grid_dim_z, tb_dim_x, tb_dim_y, tb_dim_z;
   unsigned tb_id_x, tb_id_y, tb_id_z, tb_id, warpid_tb;
+  unsigned lineinfo, linenum;
   string line;
   stringstream ss;
   string string1, string2;
@@ -123,6 +124,8 @@ void group_per_block(const char *filepath) {
         sscanf(line.c_str(), "-block dim = (%d,%d,%d)", &tb_dim_x, &tb_dim_y,
                &tb_dim_z);
         found_block_dim = true;
+      } else if (string1 == "enable" && string2 == "lineinfo") {
+        sscanf(line.c_str(), "-enable lineinfo = %d", &lineinfo);
       }
 
       if (found_grid_dim && found_block_dim) {


### PR DESCRIPTION
Adds source code line number support to tracer. Indicates which line of code produced each SASS instruction. Refer to updated readme.

Relies on PR https://github.com/accel-sim/gpu-app-collection/pull/12 to output correct line numbers.