### PR TITLE
Updating the GPGPU-Sim Build flow to make the version of GPGPU-sim you are using more explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ sim_run_*
 4.2/
 gpucomputingsdk_4.2.9_linux.run
 util/job_launching/*.txt
+gpu-simulator/gpgpu-sim

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,7 @@ pipeline {
                 sh '''#!/bin/bash -xe
                 source ./env-setup/11.2.1_env_setup.sh
                 rm -rf ./gpu-simulator/gpgpu-sim
-                source ./gpu-simulator/setup_environment.sh
-                make -j -C gpu-simulator
+                source ./gpu-simulator/setup_environment.sh < /dev/null
                 make clean -C gpu-simulator
                 make -j -C gpu-simulator'''
             }
@@ -30,7 +29,7 @@ pipeline {
                 parallel "sass": {
                 sh '''#!/bin/bash -xe
                 source ./env-setup/11.2.1_env_setup.sh
-                source ./gpu-simulator/setup_environment.sh
+                source ./gpu-simulator/setup_environment.sh < /dev/null
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C QV100-SASS -T ~/../common/accel-sim/traces/volta-tesla-v100/latest/ -N sass-short-${BUILD_NUMBER}
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C RTX2060-SASS -T ~/../common/accel-sim/traces/turing-rtx2060/latest/ -N sass-short-${BUILD_NUMBER}
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C RTX3070-SASS -T ~/../common/accel-sim/traces/ampere-rtx3070/latest/ -N sass-short-${BUILD_NUMBER}
@@ -38,7 +37,7 @@ pipeline {
                }, "ptx": {
                 sh '''#!/bin/bash -xe
                 source ./env-setup/11.2.1_env_setup.sh
-                source ./gpu-simulator/setup_environment.sh
+                source ./gpu-simulator/setup_environment.sh < /dev/null
 
                 rm -rf ./gpu-app-collection
                 git clone git@github.com:accel-sim/gpu-app-collection.git

--- a/gpu-simulator/Makefile
+++ b/gpu-simulator/Makefile
@@ -51,7 +51,7 @@ makedirs:
 	if [ ! -d $(BUILD_DIR) ]; then mkdir -p $(BUILD_DIR); fi;
 
 gpgpu-sim: checkenv makedirs
-	$(MAKE) -C gpgpu-sim
+	$(MAKE) -C $(GPGPUSIM_ROOT)
 
 checkenv: makedirs
 	 @if [ ! -n "$(ACCELSIM_SETUP_ENVIRONMENT_WAS_RUN)" ]; then \
@@ -83,7 +83,7 @@ trace-parser: checkenv makedirs
 clean:
 	rm -rf $(BIN_DIR)
 	rm -rf $(BUILD_DIR)
-	$(MAKE) clean -C gpgpu-sim
+	$(MAKE) clean -C $(GPGPUSIM_ROOT)
 
 
 include $(BUILD_DIR)/main.makedepend

--- a/gpu-simulator/setup_environment.sh
+++ b/gpu-simulator/setup_environment.sh
@@ -41,13 +41,8 @@ else
     export ACCELSIM_CONFIG=release
 fi
 
-# If the setup environment was already run and the root folder for GPGPU-Sim exists, then just use it
-if [ ! -z "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" -a -d "$GPGPUSIM_ROOT" ]; then
-    echo "Using \$GPGPUSIM_ROOT=\"$GPGPUSIM_ROOT\"."
-    echo "Assuming GPGPU-Sim is located here - and not running gpgpu-sim's setup enironment."
-    echo "If that is not the intended behavior, then run: \"unset GPGPUSIM_ROOT; unset GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN\"."
 # If we can't find an already set version of GPGPU-Sim, then pull one locally using the repos specificed above
-else
+if [ -z "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" -o ! -d "$GPGPUSIM_ROOT" ]; then
     echo "No \$GPGPUSIM_ROOT, testing for local folder in: \"$ACCELSIM_ROOT/gpgpu-sim\""
     if [ ! -d "$ACCELSIM_ROOT/gpgpu-sim" ] ; then
         echo "No \$ACCELSIM_ROOT/gpgpu-sim."
@@ -65,7 +60,9 @@ else
     else
         echo "Found $ACCELSIM_ROOT/gpgpu-sim, using existing local location. Not sycning anything."
     fi
-    source $ACCELSIM_ROOT/gpgpu-sim/setup_environment $ACCELSIM_CONFIG
 fi
 
+source $GPGPUSIM_ROOT/setup_environment $ACCELSIM_CONFIG
+echo "Accel-Sim setup succeeded, using GPGPU-Sim in $GPGPUSIM_ROOT"
+#echo "If that is not the intended behavior, then run: \"unset GPGPUSIM_ROOT; unset GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN\"."
 export ACCELSIM_SETUP_ENVIRONMENT_WAS_RUN=1

--- a/gpu-simulator/setup_environment.sh
+++ b/gpu-simulator/setup_environment.sh
@@ -50,9 +50,18 @@ if [ ! -z "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" -a -d "$GPGPUSIM_ROOT" ]; then
 else
     echo "No \$GPGPUSIM_ROOT, testing for local folder in: \"$ACCELSIM_ROOT/gpgpu-sim\""
     if [ ! -d "$ACCELSIM_ROOT/gpgpu-sim" ] ; then
-        echo "No \$ACCELSIM_ROOT/gpgpu-sim, syncing to $GPGPUSIM_REPO"
-        git clone $GPGPUSIM_REPO $ACCELSIM_ROOT/gpgpu-sim
-        git -C $ACCELSIM_ROOT/gpgpu-sim/ checkout $GPGPUSIM_BRANCH
+        echo "No \$ACCELSIM_ROOT/gpgpu-sim."
+        read -e -p "Please specify the repo you want to sync for GPGPU-Sim (default is $GPGPUSIM_REPO):" user_repo
+        if [ -z $user_repo ] ; then
+            user_repo=$GPGPUSIM_REPO
+        fi
+
+        read -e -p "Please specify the branch for GPGPU-Sim you would like to use (default is $GPGPUSIM_BRANCH):" user_branch
+        if [ -z $user_branch ] ; then
+            user_branch=$GPGPUSIM_BRANCH
+        fi
+        git clone $user_repo $ACCELSIM_ROOT/gpgpu-sim
+        git -C $ACCELSIM_ROOT/gpgpu-sim/ checkout $user_branch
     else
         echo "Found $ACCELSIM_ROOT/gpgpu-sim, using existing local location. Not sycning anything."
     fi

--- a/gpu-simulator/setup_environment.sh
+++ b/gpu-simulator/setup_environment.sh
@@ -60,9 +60,12 @@ if [ -z "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" -o ! -d "$GPGPUSIM_ROOT" ]; then
     else
         echo "Found $ACCELSIM_ROOT/gpgpu-sim, using existing local location. Not sycning anything."
     fi
+    source $ACCELSIM_ROOT/gpgpu-sim/setup_environment $ACCELSIM_CONFIG
+else
+    source $GPGPUSIM_ROOT/setup_environment $ACCELSIM_CONFIG
 fi
 
-source $GPGPUSIM_ROOT/setup_environment $ACCELSIM_CONFIG
+
 echo "Accel-Sim setup succeeded, using GPGPU-Sim in $GPGPUSIM_ROOT"
 #echo "If that is not the intended behavior, then run: \"unset GPGPUSIM_ROOT; unset GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN\"."
 export ACCELSIM_SETUP_ENVIRONMENT_WAS_RUN=1

--- a/gpu-simulator/setup_environment.sh
+++ b/gpu-simulator/setup_environment.sh
@@ -46,12 +46,16 @@ if [ -z "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" -o ! -d "$GPGPUSIM_ROOT" ]; then
     echo "No \$GPGPUSIM_ROOT, testing for local folder in: \"$ACCELSIM_ROOT/gpgpu-sim\""
     if [ ! -d "$ACCELSIM_ROOT/gpgpu-sim" ] ; then
         echo "No \$ACCELSIM_ROOT/gpgpu-sim."
-        read -e -p "Please specify the repo you want to sync for GPGPU-Sim (default is $GPGPUSIM_REPO):" user_repo
+        if [ ! -z "$PS1" ]; then
+            read -e -p "Please specify the repo you want to sync for GPGPU-Sim (default is $GPGPUSIM_REPO):" user_repo
+        fi
         if [ -z $user_repo ] ; then
             user_repo=$GPGPUSIM_REPO
         fi
 
-        read -e -p "Please specify the branch for GPGPU-Sim you would like to use (default is $GPGPUSIM_BRANCH):" user_branch
+        if [ ! -z "$PS1" ]; then
+            read -e -p "Please specify the branch for GPGPU-Sim you would like to use (default is $GPGPUSIM_BRANCH):" user_branch
+        fi
         if [ -z $user_branch ] ; then
             user_branch=$GPGPUSIM_BRANCH
         fi
@@ -60,12 +64,13 @@ if [ -z "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" -o ! -d "$GPGPUSIM_ROOT" ]; then
     else
         echo "Found $ACCELSIM_ROOT/gpgpu-sim, using existing local location. Not sycning anything."
     fi
-    source $ACCELSIM_ROOT/gpgpu-sim/setup_environment $ACCELSIM_CONFIG
+    source $ACCELSIM_ROOT/gpgpu-sim/setup_environment $ACCELSIM_CONFIG || return 1
 else
-    source $GPGPUSIM_ROOT/setup_environment $ACCELSIM_CONFIG
+    source $GPGPUSIM_ROOT/setup_environment $ACCELSIM_CONFIG || return 1
 fi
 
 
-echo "Accel-Sim setup succeeded, using GPGPU-Sim in $GPGPUSIM_ROOT"
+echo "Using GPGPU-Sim in $GPGPUSIM_ROOT"
 #echo "If that is not the intended behavior, then run: \"unset GPGPUSIM_ROOT; unset GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN\"."
+echo "Accel-Sim setup succeeded."
 export ACCELSIM_SETUP_ENVIRONMENT_WAS_RUN=1


### PR DESCRIPTION
Now you can have GPGPU-Sim in many different places, and you aren't forced to sync/modify the setup_enviroment file.
I also added a user prompt (that Jenkins short circuits) to allow users to select which repo/branch they want to use when they first run setup_envuronment.
No submodules used here - still on the fence if we want to use them for GPGPU-Sim or not.