### PR TITLE
Add F2FP opcode into ISA def files of ampere and turing

### DIFF
--- a/gpu-simulator/ISA_Def/accelwattch_component_mapping.h
+++ b/gpu-simulator/ISA_Def/accelwattch_component_mapping.h
@@ -90,6 +90,7 @@ static const std::unordered_map<unsigned, unsigned> OpcodePowerMap = {
     {OP_VABSDIFF, INT__OP},
     {OP_VABSDIFF4, INT__OP},
     {OP_F2F, FP__OP},
+    {OP_F2FP, FP__OP},
     {OP_F2I, FP__OP},
     {OP_I2F, FP__OP},
     {OP_I2I, INT__OP},

--- a/gpu-simulator/ISA_Def/ampere_opcode.h
+++ b/gpu-simulator/ISA_Def/ampere_opcode.h
@@ -87,6 +87,7 @@ static const std::unordered_map<std::string, OpcodeChar> Ampere_OpcodeMap = {
 
     // Conversion Instructions
     {"F2F", OpcodeChar(OP_F2F, ALU_OP)},
+    {"F2FP", OpcodeChar(OP_F2FP, ALU_OP)},
     {"F2I", OpcodeChar(OP_F2I, ALU_OP)},
     {"I2F", OpcodeChar(OP_I2F, ALU_OP)},
     {"I2I", OpcodeChar(OP_I2I, ALU_OP)},

--- a/gpu-simulator/ISA_Def/trace_opcode.h
+++ b/gpu-simulator/ISA_Def/trace_opcode.h
@@ -225,6 +225,8 @@ enum TraceInstrOpcode {
   OP_REDUX,
   OP_UF2FP,
   OP_SUQUERY,
+  // Shared between ampere and turing
+  OP_F2FP,
   SASS_NUM_OPCODES /* The total number of opcodes. */
 };
 typedef enum TraceInstrOpcode sass_op_type;

--- a/gpu-simulator/ISA_Def/turing_opcode.h
+++ b/gpu-simulator/ISA_Def/turing_opcode.h
@@ -84,6 +84,7 @@ static const std::unordered_map<std::string, OpcodeChar> Turing_OpcodeMap = {
 
     // Conversion Instructions
     {"F2F", OpcodeChar(OP_F2F, ALU_OP)},
+    {"F2FP", OpcodeChar(OP_F2FP, ALU_OP)},
     {"F2I", OpcodeChar(OP_F2I, ALU_OP)},
     {"I2F", OpcodeChar(OP_I2F, ALU_OP)},
     {"I2I", OpcodeChar(OP_I2I, ALU_OP)},


### PR DESCRIPTION
Fix issue #213 by adding F2FP into trace ISA def files