### PR TITLE
Fix indeterministic behavior in Scoreboard::checkCollision function 

### DIFF
--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -175,6 +175,7 @@ bool trace_warp_inst_t::parse_from_trace_struct(
 
   is_vectorin = 0;
   is_vectorout = 0;
+  pred = 0;
   ar1 = 0;
   ar2 = 0;
   memory_op = no_memory_op;


### PR DESCRIPTION
Fix indeterministic behavior in Scoreboard::checkCollision (reporting false RAW/WAW)  function caused by uninitialized 'pred' variable when parsing the trace. 
