### PR TITLE
Separating QV100 and GV100. Update docs and configs.

### DIFF
--- a/AccelWattch.md
+++ b/AccelWattch.md
@@ -131,7 +131,7 @@ Once all the validation suite binaries are located at **$ACCELSIM_ROOT/../util/a
 ```
 $ACCELSIM_ROOT/../util/accelwattch/accelwattch_hw_profiler/profile_validation_perf.sh
 ```
-This will replace the pre-existing hw_perf.csv with new results. The hw_perf.csv is also copied over to **$ACCELSIM_ROOT/../gpu-simulator/gpgpu-sim/configs/tested-cfgs/SM7_QV100/** for use in subsequent AccelWattch HW and HYBRID runs.
+This will replace the pre-existing hw_perf.csv with new results. The hw_perf.csv is also copied over to **$ACCELSIM_ROOT/../gpu-simulator/gpgpu-sim/configs/tested-cfgs/SM7_GV100/** for use in subsequent AccelWattch HW and HYBRID runs.
 
 ## Building AccelWattch
 To build AccelWattch and Accel-Sim using a single CPU core, please run:
@@ -181,7 +181,7 @@ The above will create **$ACCELSIM_ROOT/../accelwattch_runs/** directory which co
 
 **NOTE:** Some Accel-Sim jobs like `cudaTensorCoreGemm` require ~20G memory to run and might get killed when out-of-memory. To relaunch individual jobs, go to the run directory and run the launch command as shown in this example:
 ```
-cd $ACCELSIM_ROOT/../accelwattch_runs/volta_sass_sim/cudaTensorCoreGemm/NO_ARGS/QV100-Accelwattch_SASS_SIM
+cd $ACCELSIM_ROOT/../accelwattch_runs/volta_sass_sim/cudaTensorCoreGemm/NO_ARGS/GV100-Accelwattch_SASS_SIM
 $ACCELSIM_ROOT/bin/release/accel-sim.out  -config ./gpgpusim.config -trace ./traces/kernelslist.g
 ```
 

--- a/AccelWattch.md
+++ b/AccelWattch.md
@@ -85,18 +85,6 @@ mkdir -p $ACCELSIM_ROOT/../util/accelwattch/accelwattch_benchmarks/validation
 cp $GPUAPPS_ROOT/bin/11.0/release/* $ACCELSIM_ROOT/../util/accelwattch/accelwattch_benchmarks/validation
 ```
 
-### Using pre-compiled binaries for AccelWattch
-
-Alternatively, you can use pre-compiled binaries located at **$ACCELSIM_ROOT/../util/accelwattch/accelwattch_benchmarks/**
-To extract pre-compiled binaries for AccelWattch:
-```
-cd $ACCELSIM_ROOT/../util/accelwattch/accelwattch_benchmarks
-./extract_binaries.sh
-```
-This will create a folder **$ACCELSIM_ROOT/../util/accelwattch/accelwattch_benchmarks/validation** with the binaries for validation workloads and a folder **$ACCELSIM_ROOT/../util/accelwattch/accelwattch_benchmarks/microbenchmarks** with the binaries for AccelWattch microbenchmarks.
-
-**NOTE:** These binaries include dynamically-linked libraries and may not run on your system. Hence, we **STRONGLY** recommend compiling the binaries yourself following the previous step above.
-
 
 ### Setting up datasets for AccelWattch Validation Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -259,20 +259,20 @@ CUDA\_INSTALL\_PATH, the run ./travis.sh.
 
 1. **Running AccelWattch SASS SIM**: To run *the simple example from bullet 1* with AccelWattch power estimations enabled using the *AccelWattch SASS SIM* model,
 ```bash
-./util/job_launching/run_simulations.py -B rodinia_2.0-ft -C QV100-Accelwattch_SASS_SIM -T ./hw_run/traces/device-<device-num>/<cuda-version>/ -N myTest
+./util/job_launching/run_simulations.py -B rodinia_2.0-ft -C GV100-Accelwattch_SASS_SIM -T ./hw_run/traces/device-<device-num>/<cuda-version>/ -N myTest
 ```
 This will use the *AccelWattch SASS SIM* xml configuration file for the power model. The configuration files for the AccelWattch power model presented in our [MICRO 2021 paper](http://paragon.cs.northwestern.edu/papers/2021-MICRO-AccelWattch-Kandiah.pdf) can be found [here](https://github.com/accel-sim/gpgpu-sim_distribution/tree/release-accelwattch/configs/tested-cfgs/SM7_QV100). Please look at `./util/job_launching/configs/define-standard-cfgs.yml` for a list of provided AccelWattch configurations. The *AccelWattch HYBRID* configuration provided there uses activity factors for L2 and NOC from Accel-Sim and the rest from hardware performance counters. You can create your own *AccelWattch HYBRID* configuration in this file with a different mix of AccelWattch activity factors from Accel-Sim and hardware execution. 
 Upon completion of simulations, AccelWattch power estimations are stored in a *accelwattch_power_report.log* in a per-kernel format in the run directory. 
 
 2. **Running AccelWattch HW or AccelWattch HYBRID:** To run *the simple example from bullet 1* with *AccelWattch HW* or *AccelWattch HYBRID* configurations, 
 ```bash
-./util/job_launching/run_simulations.py -B rodinia_2.0-ft -a -C <QV100-Accelwattch_SASS_HW or QV100-Accelwattch_SASS_HYBRID> -T ./hw_run/traces/device-<device-num>/<cuda-version>/ -N myTest
+./util/job_launching/run_simulations.py -B rodinia_2.0-ft -a -C <GV100-Accelwattch_SASS_HW or GV100-Accelwattch_SASS_HYBRID> -T ./hw_run/traces/device-<device-num>/<cuda-version>/ -N myTest
 ```
-Note that *AccelWattch HW* and *AccelWattch HYBRID* configurations require hardware performance counter information for the target application stored in a *hw_perf.csv* file in the run directory. A sample *hw_perf.csv* file with performance counter information collected from a QV100 card for validation suite benchmarks used in our [MICRO 2021 paper](http://paragon.cs.northwestern.edu/papers/2021-MICRO-AccelWattch-Kandiah.pdf) is copied over to the run directory by default with the above *run_simulations.py* command. The *-a* argument for *run_simulations.py* is used to feed the application name to AccelWattch. Please make sure that there is a hardware performance counter information entry with the same application name in *hw_perf.csv* for AccelWattch to obtain activity factors from. Please look at example entries in the provided `./util/accelwattch/accelwattch_hw_profiler/hw_perf.csv`. 
+Note that *AccelWattch HW* and *AccelWattch HYBRID* configurations require hardware performance counter information for the target application stored in a *hw_perf.csv* file in the run directory. A sample *hw_perf.csv* file with performance counter information collected from a GV100 card for validation suite benchmarks used in our [MICRO 2021 paper](http://paragon.cs.northwestern.edu/papers/2021-MICRO-AccelWattch-Kandiah.pdf) is copied over to the run directory by default with the above *run_simulations.py* command. The *-a* argument for *run_simulations.py* is used to feed the application name to AccelWattch. Please make sure that there is a hardware performance counter information entry with the same application name in *hw_perf.csv* for AccelWattch to obtain activity factors from. Please look at example entries in the provided `./util/accelwattch/accelwattch_hw_profiler/hw_perf.csv`. 
 
 3. **Running AccelWattch PTX SIM**: To run *the simple example from bullet 1* with AccelWattch power estimations enabled using the *AccelWattch PTX SIM* model,
 ```bash
-./util/job_launching/run_simulations.py -B rodinia_2.0-ft -C QV100-Accelwattch_PTX_SIM -N myTest
+./util/job_launching/run_simulations.py -B rodinia_2.0-ft -C GV100-Accelwattch_PTX_SIM -N myTest
 ```
 
 4. **Hardware Power and Performance Profiler**: The AccelWattch hardware profiler scripts are located at `./util/accelwattch/accelwattch_hw_profiler/` in this repository. For more information on how to use them, please look at [this](https://github.com/accel-sim/accel-sim-framework/blob/release-accelwattch/AccelWattch.md#hardware-profiling-for-accelwattch-validation) section in our MICRO'21 Artifact Manual.

--- a/gpu-simulator/configs/tested-cfgs/SM7_GV100/trace.config
+++ b/gpu-simulator/configs/tested-cfgs/SM7_GV100/trace.config
@@ -1,0 +1,19 @@
+-trace_opcode_latency_initiation_int 2,2
+-trace_opcode_latency_initiation_sp 2,2
+-trace_opcode_latency_initiation_dp 8,4
+-trace_opcode_latency_initiation_sfu 20,8
+-trace_opcode_latency_initiation_tensor 2,2
+
+#execute branch insts on spec unit 1
+#in Volta, there is a dedicated branch unit
+#<enabled>,<num_units>,<max_latency>,<ID_OC_SPEC>,<OC_EX_SPEC>,<NAME>
+-specialized_unit_1 1,4,4,4,4,BRA
+-trace_opcode_latency_initiation_spec_op_1 4,4
+
+#TEX unit, make fixed latency for all tex insts
+-specialized_unit_2 1,4,200,4,4,TEX
+-trace_opcode_latency_initiation_spec_op_2 200,4
+
+#tensor unit
+-specialized_unit_3 1,4,8,4,4,TENSOR
+-trace_opcode_latency_initiation_spec_op_3 2,2

--- a/util/job_launching/configs/define-standard-cfgs.yml
+++ b/util/job_launching/configs/define-standard-cfgs.yml
@@ -43,6 +43,8 @@ QV100_SASS:
 
 QV100_old:
     base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM7_QV100_old/gpgpusim.config"
+GV100:
+    base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM7_GV100/gpgpusim.config"
 
 # Fermi
 GTX480:

--- a/util/plotting/correl_mappings.py
+++ b/util/plotting/correl_mappings.py
@@ -9,7 +9,8 @@ config_maps = \
     "GTX480" : set("GeForce GTX 480"),
     "GTX1080Ti" : set("GeForce GTX 1080 Ti"),
     "TITANK" : set("GeForce GTX TITAN"),
-    "QV100" : set(["TITAN V", "Quadro GV100","Tesla V100-SXM2-32GB"]),
+    "QV100" : set(["TITAN V","Tesla V100-SXM2-32GB"]),
+    "GV100" : set("Quadro GV100"),
     "RTX2060" : set("GeForce RTX 2060"),
     "RTX3070" : set("GeForce RTX 3070"),
 }


### PR DESCRIPTION
QV100 and GV100 have the same architecture (Volta Quadro V100), but the clock freq is slightly different. 
QV100 is used in the Accel-Sim paper, while Accel-Wattach uses GV100. 