### PR TITLE
Fix semi-colon issue separating CUDA_INJECTION64_PATH and LD_PRELOAD

### DIFF
--- a/util/tracer_nvbit/run_hw_trace.py
+++ b/util/tracer_nvbit/run_hw_trace.py
@@ -104,7 +104,7 @@ for bench in benchmarks:
 	# then, we delete the intermediate files ((.trace and kernelslist files files)
         sh_contents += "\nexport CUDA_VERSION=\"" + cuda_version + "\"; export CUDA_VISIBLE_DEVICES=\"" + options.device_num + "\" ; " +\
             "export TRACES_FOLDER="+ this_trace_folder + "; CUDA_INJECTION64_PATH=" + os.path.join(nvbit_tracer_path, "tracer_tool.so") +\
-            " " + "; LD_PRELOAD=" + os.path.join(nvbit_tracer_path, "tracer_tool.so") + " " +\
+            " " + " LD_PRELOAD=" + os.path.join(nvbit_tracer_path, "tracer_tool.so") + " " +\
             exec_path + " " + str(args) + " ; " + os.path.join(nvbit_tracer_path,"traces-processing", "post-traces-processing") + " " +\
             os.path.join(this_trace_folder, "kernelslist") + " ; rm -f " + this_trace_folder + "/*.trace ; rm -f " + this_trace_folder + "/kernelslist "
 


### PR DESCRIPTION
Fix issue with CUDA_INJECTION64_PATH not being properly set before running python applications as binaries. 
The issue was an improper usage of "**_;_**", setting CUDA_INJECTION64_PATH for a blank statement.