### PR TITLE
A couple bugs that cropped up on the Jenkins restart

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C QV100-SASS -T ~/../common/accel-sim/traces/volta-tesla-v100/latest/ -N sass-short-${BUILD_NUMBER}
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C RTX2060-SASS -T ~/../common/accel-sim/traces/turing-rtx2060/latest/ -N sass-short-${BUILD_NUMBER}
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C RTX3070-SASS -T ~/../common/accel-sim/traces/ampere-rtx3070/latest/ -N sass-short-${BUILD_NUMBER}
-                ./util/job_launching/monitor_func_test.py -I -v -s stats-per-app-sass.csv -N sass-short-${BUILD_NUMBER}'''
+                ./util/job_launching/monitor_func_test.py -v -s stats-per-app-sass.csv -N sass-short-${BUILD_NUMBER}'''
                }, "ptx": {
                 sh '''#!/bin/bash -xe
                 source ./env-setup/11.2.1_env_setup.sh
@@ -46,7 +46,7 @@ pipeline {
                 ./gpu-app-collection/get_regression_data.sh
 
                 ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C QV100-PTX,RTX2060-PTX,RTX3070-PTX -N short-ptx-${BUILD_NUMBER}
-                ./util/job_launching/monitor_func_test.py -I -v -s stats-per-app-ptx.csv -N short-ptx-${BUILD_NUMBER}'''
+                ./util/job_launching/monitor_func_test.py -v -s stats-per-app-ptx.csv -N short-ptx-${BUILD_NUMBER}'''
                }
             }
         }

--- a/util/job_launching/configs/define-standard-cfgs.yml
+++ b/util/job_launching/configs/define-standard-cfgs.yml
@@ -37,10 +37,6 @@ QV100:
 QV100_64SM:
     base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM7_QV100_SMs/gpgpusim.config"
 
-
-QV100_SASS:
-    base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM7_QV100_SASS/gpgpusim.config"
-
 QV100_old:
     base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM7_QV100_old/gpgpusim.config"
 GV100:

--- a/util/job_launching/run_simulations.py
+++ b/util/job_launching/run_simulations.py
@@ -196,14 +196,13 @@ class ConfigurationSpec:
                             "a",
                         )
                         print(
-                            "%s %6s %-22s %-100s %-25s %s.%s"
+                            "%s %6s %-22s %-100s %-25s %s"
                             % (
                                 time_string,
                                 torque_out,
                                 benchmark,
                                 self.benchmark_args_subdirs[args],
                                 self.run_subdir,
-                                benchmark,
                                 build_handle,
                             ),
                             file=logfile,
@@ -309,6 +308,11 @@ class ConfigurationSpec:
             f.close()
 
         if options.trace_dir == "":
+            # If the config contains "SASS" and you have not specified the trace directory, then likely something is wrong
+            if ("SASS" in self.run_subdir):
+                print("You are trying to run a configuration with SASS in it, but have not specified a trace directory."+\
+                      " If you want to run SASS traces, please specify -T to point to the top-level trace directory")
+                exit(1)
             exec_name = (
                 options.benchmark_exec_prefix
                 + " "


### PR DESCRIPTION
Fixing a file naming error that was affecting the PTX job status and stat collection readings.
Also changed the monitor script initiation to actually fail if there are errors with the small tests.