### PR TITLE
update cutlass naming

### DIFF
--- a/util/job_launching/apps/all-apps.list
+++ b/util/job_launching/apps/all-apps.list
@@ -1,1 +1,1 @@
-sdk-4.2,rodinia_2.0-ft,dragon-naive,proxy-apps-doe1,proxy-apps-doe2,pannotia,ispass-2009,rodinia-3.1,lonestargpu-2.0,sdk-4.2-scaled,parboil,polybench,shoc,deeplearning,cutlass_10,GPU_Microbenchmark,microbench,cutlass,custom_apps
+sdk-4.2,rodinia_2.0-ft,dragon-naive,proxy-apps-doe1,proxy-apps-doe2,pannotia,ispass-2009,rodinia-3.1,lonestargpu-2.0,sdk-4.2-scaled,parboil,polybench,shoc,deeplearning,GPU_Microbenchmark,microbench,cutlass,custom_apps

--- a/util/job_launching/apps/define-all-apps.yml
+++ b/util/job_launching/apps/define-all-apps.yml
@@ -514,16 +514,16 @@ polybench:
             - args:
               accel-sim-mem: 8G
 
-cutlass_5_trace:
+cutlass:
     exec_dir: "$GPUAPPS_ROOT/bin/$CUDA_VERSION/release/"
     data_dirs: "$GPUAPPS_ROOT/data_dirs/"
     execs:
-        - cutlass_profiler:
+        - cutlass_perf_test_k1:
             #single precision gemm kernels
             - args: --seed=2020 --dist=0  --m=2560 --n=16 --k=2560 --kernels=sgemm  --iterations=5 --providers=cutlass
               accel-sim-mem: 13G
-            - args: --seed=2020 --dist=0  --m=2560 --n=32 --k=2560 --kernels=sgemm  --iterations=5 --providers=cutlass
-              accel-sim-mem: 13G
+            # - args: --seed=2020 --dist=0  --m=2560 --n=32 --k=2560 --kernels=sgemm  --iterations=5 --providers=cutlass
+            #   accel-sim-mem: 13G
             # - args: --seed=2020 --dist=0  --m=2560 --n=64 --k=2560 --kernels=sgemm  --iterations=5 --providers=cutlass
             #   accel-sim-mem: 13G
             # - args: --seed=2020 --dist=0  --m=2560 --n=128 --k=2560 --kernels=sgemm  --iterations=5 --providers=cutlass


### PR DESCRIPTION
This updates cutlass naming so it is consistent with the name used to build in gpu-app-collection. Also it makes the executable name consistent with the one used by accelwattch. See https://github.com/accel-sim/gpu-app-collection/pull/22