### PR TITLE
Implement move semantics and disable copy semantics for the new PipeReader

### DIFF
--- a/gpu-simulator/trace-parser/trace_parser.cc
+++ b/gpu-simulator/trace-parser/trace_parser.cc
@@ -474,3 +474,22 @@ bool PipeReader::hasEnding(const std::string &fullString,
   }
   return false;
 }
+
+PipeReader::PipeReader(PipeReader &&other) noexcept:
+  pipe(other.pipe),
+  command(other.command)
+{
+  other.pipe = NULL;
+  other.command = {};
+}
+
+PipeReader& PipeReader::operator=(PipeReader&&other) noexcept{
+  if(this != &other){
+    pipe = other.pipe;
+    command = other.command;
+
+    other.pipe= NULL;
+    other.command = {};
+  }
+  return *this;
+}

--- a/gpu-simulator/trace-parser/trace_parser.cc
+++ b/gpu-simulator/trace-parser/trace_parser.cc
@@ -475,20 +475,18 @@ bool PipeReader::hasEnding(const std::string &fullString,
   return false;
 }
 
-PipeReader::PipeReader(PipeReader &&other) noexcept:
-  pipe(other.pipe),
-  command(other.command)
-{
+PipeReader::PipeReader(PipeReader &&other) noexcept
+    : pipe(other.pipe), command(other.command) {
   other.pipe = NULL;
   other.command = {};
 }
 
-PipeReader& PipeReader::operator=(PipeReader&&other) noexcept{
-  if(this != &other){
+PipeReader &PipeReader::operator=(PipeReader &&other) noexcept {
+  if (this != &other) {
     pipe = other.pipe;
     command = other.command;
 
-    other.pipe= NULL;
+    other.pipe = NULL;
     other.command = {};
   }
   return *this;

--- a/gpu-simulator/trace-parser/trace_parser.h
+++ b/gpu-simulator/trace-parser/trace_parser.h
@@ -79,6 +79,13 @@ class PipeReader {
  public:
   PipeReader(const std::string &filePath);
 
+  // Destructor to close the pipe
+  ~PipeReader() {
+    if (pipe) {
+      pclose(pipe);  // Close the pipe when done
+    }
+  }
+
   // It does not make sense to implement copy semantics for PipeReader,
   // because each instance should hold a unique Linux pipe handle
   PipeReader(const PipeReader&) = delete;
@@ -87,15 +94,6 @@ class PipeReader {
   // Move semantics can be supported
   PipeReader(PipeReader &&) noexcept;
   PipeReader& operator=(PipeReader&&) noexcept;
-
-  void OpenFile(const std::string &filePath);
-
-  // Destructor to close the pipe
-  ~PipeReader() {
-    if (pipe) {
-      pclose(pipe);  // Close the pipe when done
-    }
-  }
 
   // Read one line
   bool readLine(std::string &line);
@@ -107,6 +105,8 @@ class PipeReader {
   // Helper function to check if a string ends with a specific suffix (file
   // extension)
   bool hasEnding(const std::string &fullString, const std::string &ending);
+
+  void OpenFile(const std::string &filePath);
 };
 
 struct kernel_trace_t {

--- a/gpu-simulator/trace-parser/trace_parser.h
+++ b/gpu-simulator/trace-parser/trace_parser.h
@@ -78,6 +78,16 @@ struct inst_trace_t {
 class PipeReader {
  public:
   PipeReader(const std::string &filePath);
+
+  // It does not make sense to implement copy semantics for PipeReader,
+  // because each instance should hold a unique Linux pipe handle
+  PipeReader(const PipeReader&) = delete;
+  PipeReader& operator=(const PipeReader&) = delete;
+
+  // Move semantics can be supported
+  PipeReader(PipeReader &&) noexcept;
+  PipeReader& operator=(PipeReader&&) noexcept;
+
   void OpenFile(const std::string &filePath);
 
   // Destructor to close the pipe

--- a/gpu-simulator/trace-parser/trace_parser.h
+++ b/gpu-simulator/trace-parser/trace_parser.h
@@ -88,12 +88,12 @@ class PipeReader {
 
   // It does not make sense to implement copy semantics for PipeReader,
   // because each instance should hold a unique Linux pipe handle
-  PipeReader(const PipeReader&) = delete;
-  PipeReader& operator=(const PipeReader&) = delete;
+  PipeReader(const PipeReader &) = delete;
+  PipeReader &operator=(const PipeReader &) = delete;
 
   // Move semantics can be supported
   PipeReader(PipeReader &&) noexcept;
-  PipeReader& operator=(PipeReader&&) noexcept;
+  PipeReader &operator=(PipeReader &&) noexcept;
 
   // Read one line
   bool readLine(std::string &line);


### PR DESCRIPTION
The PipeReader introduced in PR #340 holds a file handle to a unique Linux anonymous pipe. Therefore, we should prevent someone from trying to 'copy' a PipeReader class object. While there is currently no such use case in the repository, it is important to implement preventative measures before someone shoots himself in the foot. 