### PR TITLE
update correlation script for h100 and fix ncu profiler parsing bug

### DIFF
--- a/util/plotting/correl_mappings.py
+++ b/util/plotting/correl_mappings.py
@@ -12,6 +12,7 @@ config_maps = {
     "GV100": set("Quadro GV100"),
     "RTX2060": set("GeForce RTX 2060"),
     "RTX3070": set("GeForce RTX 3070"),
+    "H100" : set("NVIDIA H100 80GB HBM3"),
 }
 
 

--- a/util/plotting/plot-correlation.py
+++ b/util/plotting/plot-correlation.py
@@ -631,11 +631,12 @@ def parse_hw_csv(csv_file, hw_data, appargs, kdata, logger):
         for row in reader:
             # Begin by searching for the text line that indicates the beginning of the profile dump
             if state == "start" and len(row) > 0:
-                if "Profiling result" in row[0] or "==PROF== Disconnected" in row[0]:
+                if "ID" in row[0]:
                     state = "header_proc"
-                continue
+                else:
+                    continue
 
-            # The frist line is a header line what indicates the place of each stat on the next line
+            # The first line is a header line what indicates the place of each stat on the next line
             if state == "header_proc":
                 if "Event result" in row[0]:
                     continue


### PR DESCRIPTION
`parse_hw_csv` gets called for all the non gpc_cycle csv files. It was incorrectly determining the header row because it uses "PROF == Disconnect" to determine the last line before the header. This isn't always true though because the profile thread can disconnect before the app finishes printing. I fixed this by checking for row[0] == "ID" to find the header (which is what parse_hw_csv2 does.