### PR TITLE
fix gcc13 unit64 missing header

### DIFF
--- a/gpu-simulator/trace-parser/trace_parser.h
+++ b/gpu-simulator/trace-parser/trace_parser.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
-
+#include <stdint.h>
 #ifndef TRACE_PARSER_H
 #define TRACE_PARSER_H
 


### PR DESCRIPTION
gcc>= 13 compile error 