### PR TITLE
Add MNIST pytorch_examples

### DIFF
--- a/util/job_launching/apps/define-all-apps.yml
+++ b/util/job_launching/apps/define-all-apps.yml
@@ -790,3 +790,14 @@ mlperf_inference_no_external_datasets:
         - inference_mlperf_ssd:
             - args:
               accel-sim-mem: 60G
+
+pytorch_examples:
+    exec_dir: "$GPUAPPS_ROOT/bin/$CUDA_VERSION/release/"
+    data_dirs: ""
+    execs:
+        - inference_mnist:
+            - args:
+              accel-sim-mem: 60G
+      # - inference_vae:
+      #     - args:
+      #       accel-sim-mem: 10G


### PR DESCRIPTION
Goes with [https://github.com/accel-sim/gpu-app-collection/pull/34](https://github.com/accel-sim/gpu-app-collection/pull/34). Adds the MNIST pytorch test (16 kernels in the A30), VAE has a pathing issue that needs some workaround.