### PR TITLE
Once trace is done, mark warps as complete, flush ibuffer

### DIFF
--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -534,8 +534,10 @@ void trace_shader_core_ctx::get_pdom_stack_top_info(unsigned warp_id,
                                                     unsigned *pc,
                                                     unsigned *rpc) {
   // In trace-driven mode, we assume no control hazard
+ // if(pI){
   *pc = pI->pc;
   *rpc = pI->pc;
+  //}
 }
 
 const active_mask_t &trace_shader_core_ctx::get_active_mask(
@@ -625,9 +627,9 @@ void trace_shader_core_ctx::checkExecutionStatusAndUpdate(warp_inst_t &inst,
     inst.set_addr(t, (new_addr_type *)localaddrs, num_addrs);
   }
 
-  if (inst.op == EXIT_OPS) {
-    m_warp[inst.warp_id()]->set_completed(t);
-  }
+  //if (inst.op == EXIT_OPS) {
+  //  m_warp[inst.warp_id()]->set_completed(t);
+  //}
 }
 
 void trace_shader_core_ctx::func_exec_inst(warp_inst_t &inst) {
@@ -639,6 +641,7 @@ void trace_shader_core_ctx::func_exec_inst(warp_inst_t &inst) {
       // virtual function
       checkExecutionStatusAndUpdate(inst, t, tid);
     }
+
   }
 
   // here, we generate memory acessess and set the status if thread (done?)
@@ -648,7 +651,11 @@ void trace_shader_core_ctx::func_exec_inst(warp_inst_t &inst) {
 
   trace_shd_warp_t *m_trace_warp =
       static_cast<trace_shd_warp_t *>(m_warp[inst.warp_id()]);
-  if (m_trace_warp->trace_done() && m_trace_warp->functional_done()) {
+  if (m_trace_warp->trace_done()) {
+     for(unsigned t = 0; t < m_warp_size; t++) 
+     {
+	 m_warp[inst.warp_id()]->set_completed(t);
+     }
     m_trace_warp->ibuffer_flush();
     m_barriers.warp_exit(inst.warp_id());
   }


### PR DESCRIPTION
<Note: Not currently working> This was adapted from #36. 
Some traces contain instructions after the EXIT instruction, accel-sim dislikes this. Currently, we just edit traces to bypass this issue, this is a more correct/automated solution. This PR changes the EXIT instruction into basically a NOOP, and changes the complete condition to trace_done() (i.e. until we run out of instructions in trace, keep simulating). 
This fix works for some workloads, while breaking others.