### PR TITLE
Fix tracer

### DIFF
--- a/util/tracer_nvbit/run_hw_trace.py
+++ b/util/tracer_nvbit/run_hw_trace.py
@@ -142,8 +142,7 @@ for bench in benchmarks:
             + options.device_num
             + '" ; '
             + "\nexport DYNAMIC_KERNEL_LIMIT_START=0; export DYNAMIC_KERNEL_LIMIT_END=0;\n"
-            + "export TRACE_MULTI_PROCESS=0;"
-            + "\n export USER_DEFINED_FOLDERS=1 ;export TRACES_FOLDER="
+            + "\nexport TRACES_FOLDER="
             + this_trace_folder
             + "; CUDA_INJECTION64_PATH="
             + os.path.join(nvbit_tracer_path, "tracer_tool.so")

--- a/util/tracer_nvbit/run_hw_trace.py
+++ b/util/tracer_nvbit/run_hw_trace.py
@@ -141,7 +141,9 @@ for bench in benchmarks:
             + '"; export CUDA_VISIBLE_DEVICES="'
             + options.device_num
             + '" ; '
-            + "export USER_DEFINED_FOLDERS=1 ;export TRACES_FOLDER="
+            + "\nexport DYNAMIC_KERNEL_LIMIT_START=0; export DYNAMIC_KERNEL_LIMIT_END=0;\n"
+            + "export TRACE_MULTI_PROCESS=0;"
+            + "\n export USER_DEFINED_FOLDERS=1 ;export TRACES_FOLDER="
             + this_trace_folder
             + "; CUDA_INJECTION64_PATH="
             + os.path.join(nvbit_tracer_path, "tracer_tool.so")

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -60,7 +60,7 @@ bool active_region = true;
 
 /* Should we terminate the program once we are done tracing? */
 int terminate_after_limit_number_of_kernels_reached = 0;
-int user_defined_folders = 0;
+std::string user_defined_folders = "";
 
 /* Use xz to compress the *.trace file */
 int xz_compress_trace = 0;
@@ -114,6 +114,9 @@ void nvbit_at_init() {
   GET_VAR_INT(xz_compress_trace, "TRACE_FILE_COMPRESS", 1,
               "Create xz-compressed trace"
               "file");
+  GET_VAR_STR(user_defined_folders, "TRACES_FOLDER",  
+  "Stores traces in TRACES_FOLDER; defaults to cwd if unset.")  
+            
   std::string pad(100, '-');
   printf("%s\n", pad.c_str());
 
@@ -299,8 +302,8 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
   if (first_call == true) {
     first_call = false;
-    if(std::getenv("TRACES_FOLDER") != NULL)
-      traces_location = std::getenv("TRACES_FOLDER");
+    if(!user_defined_folders.empty())
+      traces_location = user_defined_folders;
     
     
     if (mkdir(traces_location.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -330,7 +330,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
     if (multi_process){
       std::string command = "ls -d " + trace_folder + "/run*/ 2>/dev/null | wc -l";
-
+      printf(command);
       FILE* pipe = popen(command.c_str(), "r");
       if (!pipe) {
           std::cerr << "Error: Failed to execute command.\n";

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -112,14 +112,9 @@ void nvbit_at_init() {
   GET_VAR_INT(
       terminate_after_limit_number_of_kernels_reached, "TERMINATE_UPON_LIMIT",
       0, "Stop the process once the current kernel > DYNAMIC_KERNEL_LIMIT_END");
-  GET_VAR_INT(user_defined_folders, "USER_DEFINED_FOLDERS", 0,
-              "Uses the user defined "
-              "folder TRACES_FOLDER path environment");
   GET_VAR_INT(xz_compress_trace, "TRACE_FILE_COMPRESS", 1,
               "Create xz-compressed trace"
               "file");
-  GET_VAR_INT(multi_process, "TRACE_MULTI_PROCESS", 0,
-              "write trace of each process in seperate dir");
   std::string pad(100, '-');
   printf("%s\n", pad.c_str());
 
@@ -305,9 +300,9 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
   if (first_call == true) {
     first_call = false;
-    if (user_defined_folders == 1) {
-      trace_folder = std::getenv("TRACES_FOLDER");
-    }
+    if(std::getenv("TRACES_FOLDER") != NULL)
+      traces_location = std::getenv("TRACES_FOLDER");
+    
     
     if (mkdir(traces_location.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
       if (errno == EEXIST) {
@@ -328,47 +323,35 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         active_region = false;
     }
 
-    if (multi_process){
-        std::string command = "ls -d " + trace_folder + "/run*/ 2>/dev/null | wc -l";
-        FILE* pipe = popen(command.c_str(), "r");
-        if (!pipe) {
-            std::cerr << "Error: Failed to execute command.\n";
-            return ;
-        }
     
-        int dir_count = 0;
-        fscanf(pipe, "%d", &dir_count); // Read the count
-        pclose(pipe);
-        trace_folder += "/run" + std::to_string(dir_count);
-      
-      
-      if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
-        if (errno == EEXIST) {
-          // alredy exists
-        } else {
-          // something else
-          std::cout << "cannot create folder error:" << strerror(errno)
-                    << std::endl;
-          return;
-        }
+      std::string command = "ls -d " + traces_location + "/run*/ 2>/dev/null | wc -l";
+      FILE* pipe = popen(command.c_str(), "r");
+      if (!pipe) {
+          std::cerr << "Error: Failed to execute command.\n";
+          return ;
       }
+  
+      int dir_count = 0;
+      fscanf(pipe, "%d", &dir_count); // Read the count
+      pclose(pipe);
+      traces_location += "/run" + std::to_string(dir_count);
+    
+    
+    if (mkdir(traces_location.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+      if (errno == EEXIST) {
+        // alredy exists
+      } else {
+        // something else
+        std::cout << "cannot create folder error:" << strerror(errno)
+                  << std::endl;
+        return;
+      }
+      
 
     }
 
-
-    std::string temp_traces_location = trace_folder;
-    std::string temp_kernelslist_location = trace_folder + "/kernelslist";
-    std::string temp_stats_location = trace_folder + "/stats.csv";
-    traces_location.resize(temp_traces_location.size());
-    kernelslist_location.resize(temp_kernelslist_location.size());
-    stats_location.resize(temp_stats_location.size());
-    traces_location.replace(traces_location.begin(), traces_location.end(),
-                            temp_traces_location);
-    kernelslist_location.replace(kernelslist_location.begin(),
-                                  kernelslist_location.end(),
-                                  temp_kernelslist_location);
-    stats_location.replace(stats_location.begin(), stats_location.end(),
-                            temp_stats_location);
+    std::string kernelslist_location = traces_location + "/kernelslist";
+    std::string kernelslist_location = traces_location + "/stats.csv";
     printf("\nTraces location is %s \n", traces_location.c_str());
     printf("Kernelslist location is %s \n", kernelslist_location.c_str());
     printf("Stats location is %s \n", stats_location.c_str());

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -54,7 +54,6 @@ int print_core_id = 0;
 int exclude_pred_off = 1;
 int active_from_start = 1;
 int lineinfo = 0;
-int multi_process = 0;
 /* used to select region of interest when active from start is 0 */
 bool active_region = true;
 

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -322,7 +322,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         active_region = false;
     }
 
-    
+    //this command to find the number of sub-dir and create a new sub-dir based on that
       std::string command = "ls -d " + traces_location + "/run*/ 2>/dev/null | wc -l";
       FILE* pipe = popen(command.c_str(), "r");
       if (!pipe) {
@@ -333,7 +333,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       int dir_count = 0;
       fscanf(pipe, "%d", &dir_count); // Read the count
       pclose(pipe);
-      traces_location += "/run" + std::to_string(dir_count);
+      traces_location += "/run-" + std::to_string(dir_count);
     
     
     if (mkdir(traces_location.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -309,7 +309,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       trace_folder = std::getenv("TRACES_FOLDER");
     }
     
-    if (mkdir(traces_location, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+    if (mkdir(traces_location.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
       if (errno == EEXIST) {
         // alredy exists
       } else {
@@ -343,7 +343,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       trace_folder = trace_folder+"run"+dir_count;
     
     
-    if (mkdir(trace_folder, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+    if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
       if (errno == EEXIST) {
         // alredy exists
       } else {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -54,8 +54,10 @@ int print_core_id = 0;
 int exclude_pred_off = 1;
 int active_from_start = 1;
 int lineinfo = 0;
+int multi_process = 0;
 /* used to select region of interest when active from start is 0 */
 bool active_region = true;
+
 
 /* Should we terminate the program once we are done tracing? */
 int terminate_after_limit_number_of_kernels_reached = 0;
@@ -68,10 +70,10 @@ int xz_compress_trace = 0;
 std::map<std::string, int> opcode_to_id_map;
 std::map<int, std::string> id_to_opcode_map;
 
-std::string cwd = getcwd(NULL, 0);
-std::string traces_location = cwd + "/traces/";
-std::string kernelslist_location = cwd + "/traces/kernelslist";
-std::string stats_location = cwd + "/traces/stats.csv";
+std::string trace_folder = getcwd(NULL, 0);
+std::string traces_location = trace_folder + "/traces/";
+std::string kernelslist_location = trace_folder + "/traces/kernelslist";
+std::string stats_location = trace_folder + "/traces/stats.csv";
 
 /* kernel instruction counter, updated by the GPU */
 uint64_t dynamic_kernel_limit_start =
@@ -116,6 +118,8 @@ void nvbit_at_init() {
   GET_VAR_INT(xz_compress_trace, "TRACE_FILE_COMPRESS", 1,
               "Create xz-compressed trace"
               "file");
+  GET_VAR_INT(multi_process, "TRACE_MULTI_PROCESS", 0,
+              "write trace of each process in seperate dir");
   std::string pad(100, '-');
   printf("%s\n", pad.c_str());
 
@@ -301,8 +305,11 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
   if (first_call == true) {
     first_call = false;
-
-    if (mkdir("traces", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+    if (user_defined_folders == 1) {
+      trace_folder = std::getenv("TRACES_FOLDER");
+    }
+    
+    if (mkdir(traces_location, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
       if (errno == EEXIST) {
         // alredy exists
       } else {
@@ -321,11 +328,38 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         active_region = false;
     }
 
-    if (user_defined_folders == 1) {
-      std::string usr_folder = std::getenv("TRACES_FOLDER");
-      std::string temp_traces_location = usr_folder;
-      std::string temp_kernelslist_location = usr_folder + "/kernelslist";
-      std::string temp_stats_location = usr_folder + "/stats.csv";
+    if (multi_process){
+      std::string command = "ls -d " + trace_folder + "/run*/ 2>/dev/null | wc -l";
+
+      FILE* pipe = popen(command.c_str(), "r");
+      if (!pipe) {
+          std::cerr << "Error: Failed to execute command.\n";
+          return 1;
+      }
+  
+      int dir_count = 0;
+      fscanf(pipe, "%d", &dir_count); // Read the count
+      pclose(pipe);
+      trace_folder = trace_folder+"run"+dir_count;
+    
+    
+    if (mkdir(trace_folder, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+      if (errno == EEXIST) {
+        // alredy exists
+      } else {
+        // something else
+        std::cout << "cannot create folder error:" << strerror(errno)
+                  << std::endl;
+        return;
+      }
+    }
+
+    }
+
+
+      std::string temp_traces_location = trace_folder;
+      std::string temp_kernelslist_location = trace_folder + "/kernelslist";
+      std::string temp_stats_location = trace_folder + "/stats.csv";
       traces_location.resize(temp_traces_location.size());
       kernelslist_location.resize(temp_kernelslist_location.size());
       stats_location.resize(temp_stats_location.size());
@@ -339,7 +373,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       printf("\n Traces location is %s \n", traces_location.c_str());
       printf("Kernelslist location is %s \n", kernelslist_location.c_str());
       printf("Stats location is %s \n", stats_location.c_str());
-    }
+    
 
     kernelsFile = fopen(kernelslist_location.c_str(), "w");
     statsFile = fopen(stats_location.c_str(), "w");

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -334,13 +334,13 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       FILE* pipe = popen(command.c_str(), "r");
       if (!pipe) {
           std::cerr << "Error: Failed to execute command.\n";
-          return 1;
+          return ;
       }
   
       int dir_count = 0;
       fscanf(pipe, "%d", &dir_count); // Read the count
       pclose(pipe);
-      trace_folder = trace_folder+"run"+dir_count;
+      trace_folder = trace_folder+string("run")+string(dir_count);
     
     
     if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -340,7 +340,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       int dir_count = 0;
       fscanf(pipe, "%d", &dir_count); // Read the count
       pclose(pipe);
-      trace_folder = trace_folder+string("run")+string(dir_count);
+      trace_folder += "run" + std::to_string(dir_count);
     
     
     if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -330,7 +330,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
     if (multi_process){
       std::string command = "ls -d " + trace_folder + "/run*/ 2>/dev/null | wc -l";
-      printf(command);
+      printf(command.c_str());
       FILE* pipe = popen(command.c_str(), "r");
       if (!pipe) {
           std::cerr << "Error: Failed to execute command.\n";

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -325,7 +325,8 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         active_region = false;
     }
 
-    //this command to find the number of sub-dir and create a new sub-dir based on that
+      // This command will find the number of sub-dirs, we then create a new sub-dir by adding 1 to the
+      // existing number of sub dirs. i.e. "run-n"
       std::string command = "ls -d " + traces_location + "/run*/ 2>/dev/null | wc -l";
       FILE* pipe = popen(command.c_str(), "r");
       if (!pipe) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -350,8 +350,8 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
     }
 
-    std::string kernelslist_location = traces_location + "/kernelslist";
-    std::string kernelslist_location = traces_location + "/stats.csv";
+    kernelslist_location = traces_location + "/kernelslist";
+    stats_location = traces_location + "/stats.csv";
     printf("\nTraces location is %s \n", traces_location.c_str());
     printf("Kernelslist location is %s \n", kernelslist_location.c_str());
     printf("Stats location is %s \n", stats_location.c_str());

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -329,50 +329,49 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
     }
 
     if (multi_process){
-      std::string command = "ls -d " + trace_folder + "/run*/ 2>/dev/null | wc -l";
-      printf(command.c_str());
-      FILE* pipe = popen(command.c_str(), "r");
-      if (!pipe) {
-          std::cerr << "Error: Failed to execute command.\n";
-          return ;
-      }
-  
-      int dir_count = 0;
-      fscanf(pipe, "%d", &dir_count); // Read the count
-      pclose(pipe);
-      trace_folder += "/run" + std::to_string(dir_count);
+        std::string command = "ls -d " + trace_folder + "/run*/ 2>/dev/null | wc -l";
+        FILE* pipe = popen(command.c_str(), "r");
+        if (!pipe) {
+            std::cerr << "Error: Failed to execute command.\n";
+            return ;
+        }
     
-    
-    if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
-      if (errno == EEXIST) {
-        // alredy exists
-      } else {
-        // something else
-        std::cout << "cannot create folder error:" << strerror(errno)
-                  << std::endl;
-        return;
+        int dir_count = 0;
+        fscanf(pipe, "%d", &dir_count); // Read the count
+        pclose(pipe);
+        trace_folder += "/run" + std::to_string(dir_count);
+      
+      
+      if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+        if (errno == EEXIST) {
+          // alredy exists
+        } else {
+          // something else
+          std::cout << "cannot create folder error:" << strerror(errno)
+                    << std::endl;
+          return;
+        }
       }
+
     }
 
-    }
 
-
-      std::string temp_traces_location = trace_folder;
-      std::string temp_kernelslist_location = trace_folder + "/kernelslist";
-      std::string temp_stats_location = trace_folder + "/stats.csv";
-      traces_location.resize(temp_traces_location.size());
-      kernelslist_location.resize(temp_kernelslist_location.size());
-      stats_location.resize(temp_stats_location.size());
-      traces_location.replace(traces_location.begin(), traces_location.end(),
-                              temp_traces_location);
-      kernelslist_location.replace(kernelslist_location.begin(),
-                                   kernelslist_location.end(),
-                                   temp_kernelslist_location);
-      stats_location.replace(stats_location.begin(), stats_location.end(),
-                             temp_stats_location);
-      printf("\n Traces location is %s \n", traces_location.c_str());
-      printf("Kernelslist location is %s \n", kernelslist_location.c_str());
-      printf("Stats location is %s \n", stats_location.c_str());
+    std::string temp_traces_location = trace_folder;
+    std::string temp_kernelslist_location = trace_folder + "/kernelslist";
+    std::string temp_stats_location = trace_folder + "/stats.csv";
+    traces_location.resize(temp_traces_location.size());
+    kernelslist_location.resize(temp_kernelslist_location.size());
+    stats_location.resize(temp_stats_location.size());
+    traces_location.replace(traces_location.begin(), traces_location.end(),
+                            temp_traces_location);
+    kernelslist_location.replace(kernelslist_location.begin(),
+                                  kernelslist_location.end(),
+                                  temp_kernelslist_location);
+    stats_location.replace(stats_location.begin(), stats_location.end(),
+                            temp_stats_location);
+    printf("\nTraces location is %s \n", traces_location.c_str());
+    printf("Kernelslist location is %s \n", kernelslist_location.c_str());
+    printf("Stats location is %s \n", stats_location.c_str());
     
 
     kernelsFile = fopen(kernelslist_location.c_str(), "w");

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -340,7 +340,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       int dir_count = 0;
       fscanf(pipe, "%d", &dir_count); // Read the count
       pclose(pipe);
-      trace_folder += "run" + std::to_string(dir_count);
+      trace_folder += "/run" + std::to_string(dir_count);
     
     
     if (mkdir(trace_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {


### PR DESCRIPTION
mlperf scripts is running multiprocesses which was causing kernelslist file and stats file to be overwritten. 


now , for each process we create a seperate dir inside traces dirs , run0 run1 ... etc

added env variable to make tracer aware of the behaviour , called it TRACE_MULTI_PROCESS