### PR TITLE
Fix: Ignore CALL.REL.NOINC to Prevent NVBit 1.7.4 Bug

### DIFF
--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -154,6 +154,13 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
     /* iterate on all the static instructions in the function */
     for (auto instr : instrs) {
       uint32_t line_num = 0;
+      // Temporary workaround for a bug in NVBit 1.7.4, which does not correctly handle `call.rel`.  
+      // Instrumenting this instruction leads to illegal memory access.  
+      // Refer to: https://github.com/NVlabs/NVBit/issues/142#issue-2911561744  
+      if(!strcmp(instr->getOpcode(), "CALL.REL.NOINC")){
+        printf("Warning: Ignoring CALL.REL.NOINC (NVBit 1.7.4 bug)\n");
+        continue;
+      } 
 
       if (cnt < instr_begin_interval || cnt >= instr_end_interval) {
         cnt++;


### PR DESCRIPTION
This PR adds a temporary fix to ignore CALL.REL.NOINC instructions, preventing illegal memory access caused by a known bug in NVBit 1.7.4 ([issue #142](https://github.com/NVlabs/NVBit/issues/142#issue-2911561744)).

Changes
Skips instrumentation for CALL.REL.NOINC.
Adds a warning message when the instruction is ignored.
Impact
Prevents crashes due to invalid memory accesses while maintaining functionality.

Notes
This is a temporary workaround until NVBit resolves the issue.