### PR TITLE
Update tracing to enable multi context

### DIFF
--- a/util/tracer_nvbit/run_hw_trace.py
+++ b/util/tracer_nvbit/run_hw_trace.py
@@ -143,7 +143,7 @@ for bench in benchmarks:
             + '" ; '
             + "\nexport DYNAMIC_KERNEL_LIMIT_START=0; export DYNAMIC_KERNEL_LIMIT_END=0;\n"
             + "\nexport TRACES_FOLDER="
-            + this_trace_folder
+            + this_run_dir
             + "; CUDA_INJECTION64_PATH="
             + os.path.join(nvbit_tracer_path, "tracer_tool.so")
             + " "
@@ -158,7 +158,7 @@ for bench in benchmarks:
                 nvbit_tracer_path, "traces-processing", "post-traces-processing"
             )
             + " "
-            + os.path.join(this_trace_folder, "kernelslist")
+            + this_trace_folder
             + " ; rm -f "
             + this_trace_folder
             + "/*.trace ; rm -f "

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 /* every tool needs to include this once */
 #include "nvbit_tool.h"
@@ -74,9 +75,10 @@ std::string traces_location = cwd + "/traces/";
 std::string kernelslist_location = cwd + "/traces/kernelslist";
 std::string stats_location = cwd + "/traces/stats.csv";
 
-std::unordered_set<CUcontext, std::string> ctx_kernelslist;
-std::unordered_set<CUcontext, std::string> ctx_stats_location;
-std::unordered_set<CUcontext, int> ctx_kernelid;
+std::unordered_map<CUcontext, std::string> ctx_kernelslist;
+std::unordered_map<CUcontext, std::string> ctx_stats_location;
+std::unordered_map<CUcontext, int> ctx_kernelid;
+std::unordered_map<CUcontext, FILE*> ctx_resultsFile;
 
 /* kernel instruction counter, updated by the GPU */
 uint64_t dynamic_kernel_limit_start =
@@ -127,8 +129,7 @@ void nvbit_at_init() {
   if (active_from_start == 0) {
     active_region = false;
   }
-  
-  std::string usr_defined_folder = std::getenv("TRACES_FOLDER");
+  char * usr_defined_folder = std::getenv("TRACES_FOLDER");
   if (usr_defined_folder != NULL)
     user_folder = usr_defined_folder;
 
@@ -388,53 +389,55 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         stop_report = true;
       }
 
-      char buffer[1024];
-      sprintf(buffer, std::string(traces_location + "/kernel-%d.trace").c_str(),
-              ctx_kernelid[ctx]);
+      char buffer[2048];
+      std::string trace_filename = user_folder + "/traces/"; 
+      sprintf(buffer, "%s/kernel-%d-ctx_0x%lx.trace", trace_filename.c_str(),
+              ctx_kernelid[ctx], ctx);
 
       if (!stop_report) {
         if (!xz_compress_trace) {
-          resultsFile = fopen(buffer, "w");
+          ctx_resultsFile[ctx] = fopen(buffer, "w");
           printf("Writing results to %s\n", buffer);
         } else {
           char cmd_buffer[1039];
           sprintf(cmd_buffer, "xz -1 -T0 > %s.xz", buffer);
-          resultsFile = popen(cmd_buffer, "w");
+          ctx_resultsFile[ctx] = popen(cmd_buffer, "w");
           printf("Writing results to %s.xz\n", buffer);
         }
 
-        fprintf(resultsFile, "-kernel name = %s\n",
+        fprintf(ctx_resultsFile[ctx], "-kernel name = %s\n",
                 nvbit_get_func_name(ctx, p->f, true));
-        fprintf(resultsFile, "-kernel id = %d\n", ctx_kernelid[ctx]);
-        fprintf(resultsFile, "-grid dim = (%d,%d,%d)\n", p->gridDimX,
+        fprintf(ctx_resultsFile[ctx], "-kernel id = %d\n", ctx_kernelid[ctx]);
+        fprintf(ctx_resultsFile[ctx], "-grid dim = (%d,%d,%d)\n", p->gridDimX,
                 p->gridDimY, p->gridDimZ);
-        fprintf(resultsFile, "-block dim = (%d,%d,%d)\n", p->blockDimX,
+        fprintf(ctx_resultsFile[ctx], "-block dim = (%d,%d,%d)\n", p->blockDimX,
                 p->blockDimY, p->blockDimZ);
-        fprintf(resultsFile, "-shmem = %d\n",
+        fprintf(ctx_resultsFile[ctx], "-shmem = %d\n",
                 shmem_static_nbytes + p->sharedMemBytes);
-        fprintf(resultsFile, "-nregs = %d\n", nregs);
-        fprintf(resultsFile, "-binary version = %d\n", binary_version);
-        fprintf(resultsFile, "-cuda stream id = %lu\n", (uint64_t)p->hStream);
-        fprintf(resultsFile, "-shmem base_addr = 0x%016lx\n",
+        fprintf(ctx_resultsFile[ctx], "-nregs = %d\n", nregs);
+        fprintf(ctx_resultsFile[ctx], "-binary version = %d\n", binary_version);
+        fprintf(ctx_resultsFile[ctx], "-cuda stream id = %lu\n", (uint64_t)p->hStream);
+        fprintf(ctx_resultsFile[ctx], "-shmem base_addr = 0x%016lx\n",
                 (uint64_t)nvbit_get_shmem_base_addr(ctx));
-        fprintf(resultsFile, "-local mem base_addr = 0x%016lx\n",
+        fprintf(ctx_resultsFile[ctx], "-local mem base_addr = 0x%016lx\n",
                 (uint64_t)nvbit_get_local_mem_base_addr(ctx));
-        fprintf(resultsFile, "-nvbit version = %s\n", NVBIT_VERSION);
-        fprintf(resultsFile, "-accelsim tracer version = %s\n", TRACER_VERSION);
-        fprintf(resultsFile, "-enable lineinfo = %d\n", lineinfo);
-        fprintf(resultsFile, "\n");
+        fprintf(ctx_resultsFile[ctx], "-nvbit version = %s\n", NVBIT_VERSION);
+        fprintf(ctx_resultsFile[ctx], "-accelsim tracer version = %s\n", TRACER_VERSION);
+        fprintf(ctx_resultsFile[ctx], "-enable lineinfo = %d\n", lineinfo);
+        fprintf(ctx_resultsFile[ctx], "\n");
 
-        fprintf(resultsFile,
+        fprintf(ctx_resultsFile[ctx],
                 "#traces format = [line_num] PC mask dest_num [reg_dests] "
                 "opcode src_num "
                 "[reg_srcs] mem_width [adrrescompress?] [mem_addresses] "
                 "immediate\n");
-        fprintf(resultsFile, "\n");
+        fprintf(ctx_resultsFile[ctx], "\n");
       }
 
       kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "a");
       // This will be a relative path to the traces file
-      sprintf(buffer, "kernel-%d.trace%s", ctx_kernelid[ctx],
+      
+      sprintf(buffer, "kernel-%d-ctx_0x%lx.trace%s", ctx_kernelid[ctx], ctx,
               xz_compress_trace ? ".xz" : "");
       if (!stop_report) {
         fprintf(kernelsFile, buffer);
@@ -496,14 +499,14 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
       if (!stop_report) {
         if (!xz_compress_trace) {
-          fclose(resultsFile);
+          fclose(ctx_resultsFile[ctx]);
         } else {
-          pclose(resultsFile);
+          pclose(ctx_resultsFile[ctx]);
         }
       }
 
       if (active_from_start && dynamic_kernel_limit_end &&
-          kernelid[ctx] > dynamic_kernel_limit_end)
+          ctx_kernelid[ctx] > dynamic_kernel_limit_end)
         active_region = false;
     }
   } else if (cbid == API_CUDA_cuProfilerStart && is_exit) {
@@ -603,7 +606,8 @@ void base_delta_compress(const uint64_t *addrs, const std::bitset<32> &mask,
   }
 }
 
-void *recv_thread_fun(void *) {
+void *recv_thread_fun(void *args) {
+  CUcontext ctx = (CUcontext)args;
   char *recv_buffer = (char *)malloc(CHANNEL_SIZE);
   while (recv_thread_started) {
     uint32_t num_recv_bytes = 0;
@@ -620,36 +624,36 @@ void *recv_thread_fun(void *) {
           break;
         }
 
-        fprintf(resultsFile, "%d ", ma->cta_id_x);
-        fprintf(resultsFile, "%d ", ma->cta_id_y);
-        fprintf(resultsFile, "%d ", ma->cta_id_z);
-        fprintf(resultsFile, "%d ", ma->warpid_tb);
+        fprintf(ctx_resultsFile[ctx], "%d ", ma->cta_id_x);
+        fprintf(ctx_resultsFile[ctx], "%d ", ma->cta_id_y);
+        fprintf(ctx_resultsFile[ctx], "%d ", ma->cta_id_z);
+        fprintf(ctx_resultsFile[ctx], "%d ", ma->warpid_tb);
         if (print_core_id) {
-          fprintf(resultsFile, "%d ", ma->sm_id);
-          fprintf(resultsFile, "%d ", ma->warpid_sm);
+          fprintf(ctx_resultsFile[ctx], "%d ", ma->sm_id);
+          fprintf(ctx_resultsFile[ctx], "%d ", ma->warpid_sm);
         }
         if (lineinfo) {
-          fprintf(resultsFile, "%d ", ma->line_num);
+          fprintf(ctx_resultsFile[ctx], "%d ", ma->line_num);
         }
-        fprintf(resultsFile, "%04x ", ma->vpc); // Print the virtual PC
-        fprintf(resultsFile, "%08x ", ma->active_mask & ma->predicate_mask);
+        fprintf(ctx_resultsFile[ctx], "%04x ", ma->vpc); // Print the virtual PC
+        fprintf(ctx_resultsFile[ctx], "%08x ", ma->active_mask & ma->predicate_mask);
         if (ma->GPRDst >= 0) {
-          fprintf(resultsFile, "1 ");
-          fprintf(resultsFile, "R%d ", ma->GPRDst);
+          fprintf(ctx_resultsFile[ctx], "1 ");
+          fprintf(ctx_resultsFile[ctx], "R%d ", ma->GPRDst);
         } else
-          fprintf(resultsFile, "0 ");
+          fprintf(ctx_resultsFile[ctx], "0 ");
 
         // Print the opcode.
-        fprintf(resultsFile, "%s ", id_to_opcode_map[ma->opcode_id].c_str());
+        fprintf(ctx_resultsFile[ctx], "%s ", id_to_opcode_map[ma->opcode_id].c_str());
         unsigned src_count = 0;
         for (int s = 0; s < MAX_SRC; s++) // GPR srcs count.
           if (ma->GPRSrcs[s] >= 0)
             src_count++;
-        fprintf(resultsFile, "%d ", src_count);
+        fprintf(ctx_resultsFile[ctx], "%d ", src_count);
 
         for (int s = 0; s < MAX_SRC; s++) // GPR srcs.
           if (ma->GPRSrcs[s] >= 0)
-            fprintf(resultsFile, "R%d ", ma->GPRSrcs[s]);
+            fprintf(ctx_resultsFile[ctx], "R%d ", ma->GPRSrcs[s]);
 
         // print addresses
         std::bitset<32> mask(ma->active_mask & ma->predicate_mask);
@@ -661,7 +665,7 @@ void *recv_thread_fun(void *) {
             if (!token.empty())
               tokens.push_back(token);
           }
-          fprintf(resultsFile, "%d ", get_datawidth_from_opcode(tokens));
+          fprintf(ctx_resultsFile[ctx], "%d ", get_datawidth_from_opcode(tokens));
 
           bool base_stride_success = false;
           uint64_t base_addr = 0;
@@ -680,31 +684,31 @@ void *recv_thread_fun(void *) {
 
           if (base_stride_success && enable_compress) {
             // base + stride format
-            fprintf(resultsFile, "%u 0x%llx %d ", address_format::base_stride,
+            fprintf(ctx_resultsFile[ctx], "%u 0x%llx %d ", address_format::base_stride,
                     base_addr, stride);
           } else if (!base_stride_success && enable_compress) {
             // base + delta format
-            fprintf(resultsFile, "%u 0x%llx ", address_format::base_delta,
+            fprintf(ctx_resultsFile[ctx], "%u 0x%llx ", address_format::base_delta,
                     base_addr);
             for (int s = 0; s < deltas.size(); s++) {
-              fprintf(resultsFile, "%lld ", deltas[s]);
+              fprintf(ctx_resultsFile[ctx], "%lld ", deltas[s]);
             }
           } else {
             // list all the addresses
-            fprintf(resultsFile, "%u ", address_format::list_all);
+            fprintf(ctx_resultsFile[ctx], "%u ", address_format::list_all);
             for (int s = 0; s < 32; s++) {
               if (mask.test(s))
-                fprintf(resultsFile, "0x%016lx ", ma->addrs[s]);
+                fprintf(ctx_resultsFile[ctx], "0x%016lx ", ma->addrs[s]);
             }
           }
         } else {
-          fprintf(resultsFile, "0 ");
+          fprintf(ctx_resultsFile[ctx], "0 ");
         }
 
         // Print the immediate
-        fprintf(resultsFile, "%d ", ma->imm);
+        fprintf(ctx_resultsFile[ctx], "%d ", ma->imm);
 
-        fprintf(resultsFile, "\n");
+        fprintf(ctx_resultsFile[ctx], "\n");
 
         num_processed_bytes += sizeof(inst_trace_t);
       }
@@ -717,7 +721,7 @@ void *recv_thread_fun(void *) {
 void nvbit_tool_init(CUcontext ctx) {
   recv_thread_started = true;
   channel_host.init(0, CHANNEL_SIZE, &channel_dev, NULL);
-  pthread_create(&recv_thread, NULL, recv_thread_fun, NULL);
+  pthread_create(&recv_thread, NULL, recv_thread_fun, ctx);
 }
 
 void nvbit_at_ctx_term(CUcontext ctx) {
@@ -730,9 +734,12 @@ void nvbit_at_ctx_term(CUcontext ctx) {
 void nvbit_at_ctx_init(CUcontext ctx)
 {
   // Everytime we init a context, add the foldername and kernelid to the set
-  std::string tmp_kernelslist = user_folder + "/kernelslist_ctx_" + std::to_string((uint64_t)ctx);
-  ctx_foldername[ctx] = tmp_kernelslist;
-  std::string tmp_stats = user_folder + "/stats_ctx_" + std::to_string((uint64_t)ctx);
+  char buffer[2048];
+  sprintf(buffer, "kernelslist_ctx_0x%lx", ctx);
+  std::string tmp_kernelslist = user_folder + "/traces/" + buffer;
+  ctx_kernelslist[ctx] = tmp_kernelslist;
+  sprintf(buffer, "stats_ctx_0x%lx", ctx);
+  std::string tmp_stats = user_folder + "/traces/" + buffer;
   ctx_stats_location[ctx] = tmp_stats;
   ctx_kernelid[ctx] = 1;
 }

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -68,10 +68,15 @@ int xz_compress_trace = 0;
 std::map<std::string, int> opcode_to_id_map;
 std::map<int, std::string> id_to_opcode_map;
 
+std::string user_folder = getcwd(NULL, 0);
 std::string cwd = getcwd(NULL, 0);
 std::string traces_location = cwd + "/traces/";
 std::string kernelslist_location = cwd + "/traces/kernelslist";
 std::string stats_location = cwd + "/traces/stats.csv";
+
+std::unordered_set<CUcontext, std::string> ctx_kernelslist;
+std::unordered_set<CUcontext, std::string> ctx_stats_location;
+std::unordered_set<CUcontext, int> ctx_kernelid;
 
 /* kernel instruction counter, updated by the GPU */
 uint64_t dynamic_kernel_limit_start =
@@ -122,6 +127,11 @@ void nvbit_at_init() {
   if (active_from_start == 0) {
     active_region = false;
   }
+  
+  std::string usr_defined_folder = std::getenv("TRACES_FOLDER");
+  if (usr_defined_folder != NULL)
+    user_folder = usr_defined_folder;
+
 }
 
 /* Set used to avoid re-instrumenting the same functions multiple times */
@@ -301,8 +311,8 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
   if (first_call == true) {
     first_call = false;
-
-    if (mkdir("traces", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+    std::string traces_folder = user_folder + "/traces";
+    if (mkdir(traces_folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
       if (errno == EEXIST) {
         // alredy exists
       } else {
@@ -321,28 +331,8 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         active_region = false;
     }
 
-    if (user_defined_folders == 1) {
-      std::string usr_folder = std::getenv("TRACES_FOLDER");
-      std::string temp_traces_location = usr_folder;
-      std::string temp_kernelslist_location = usr_folder + "/kernelslist";
-      std::string temp_stats_location = usr_folder + "/stats.csv";
-      traces_location.resize(temp_traces_location.size());
-      kernelslist_location.resize(temp_kernelslist_location.size());
-      stats_location.resize(temp_stats_location.size());
-      traces_location.replace(traces_location.begin(), traces_location.end(),
-                              temp_traces_location);
-      kernelslist_location.replace(kernelslist_location.begin(),
-                                   kernelslist_location.end(),
-                                   temp_kernelslist_location);
-      stats_location.replace(stats_location.begin(), stats_location.end(),
-                             temp_stats_location);
-      printf("\n Traces location is %s \n", traces_location.c_str());
-      printf("Kernelslist location is %s \n", kernelslist_location.c_str());
-      printf("Stats location is %s \n", stats_location.c_str());
-    }
-
-    kernelsFile = fopen(kernelslist_location.c_str(), "w");
-    statsFile = fopen(stats_location.c_str(), "w");
+    kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "w");
+    statsFile = fopen(ctx_stats_location[ctx].c_str(), "w");
     fprintf(statsFile,
             "kernel id, kernel mangled name, grid_dimX, grid_dimY, grid_dimZ, "
             "#blocks, block_dimX, block_dimY, block_dimZ, #threads, "
@@ -354,7 +344,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
     if (!is_exit) {
       cuMemcpyHtoD_v2_params *p = (cuMemcpyHtoD_v2_params *)params;
       char buffer[1024];
-      kernelsFile = fopen(kernelslist_location.c_str(), "a");
+      kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "a");
       sprintf(buffer, "MemcpyHtoD,0x%016lx,%lld", p->dstDevice, p->ByteCount);
       fprintf(kernelsFile, buffer);
       fprintf(kernelsFile, "\n");
@@ -367,12 +357,12 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
     if (!is_exit) {
       if (active_from_start && dynamic_kernel_limit_start &&
-          kernelid == dynamic_kernel_limit_start)
+          ctx_kernelid[ctx] == dynamic_kernel_limit_start)
         active_region = true;
 
       if (terminate_after_limit_number_of_kernels_reached &&
           dynamic_kernel_limit_end != 0 &&
-          kernelid > dynamic_kernel_limit_end) {
+          ctx_kernelid[ctx] > dynamic_kernel_limit_end) {
         exit(0);
       }
 
@@ -400,7 +390,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
       char buffer[1024];
       sprintf(buffer, std::string(traces_location + "/kernel-%d.trace").c_str(),
-              kernelid);
+              ctx_kernelid[ctx]);
 
       if (!stop_report) {
         if (!xz_compress_trace) {
@@ -415,7 +405,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
         fprintf(resultsFile, "-kernel name = %s\n",
                 nvbit_get_func_name(ctx, p->f, true));
-        fprintf(resultsFile, "-kernel id = %d\n", kernelid);
+        fprintf(resultsFile, "-kernel id = %d\n", ctx_kernelid[ctx]);
         fprintf(resultsFile, "-grid dim = (%d,%d,%d)\n", p->gridDimX,
                 p->gridDimY, p->gridDimZ);
         fprintf(resultsFile, "-block dim = (%d,%d,%d)\n", p->blockDimX,
@@ -442,9 +432,9 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         fprintf(resultsFile, "\n");
       }
 
-      kernelsFile = fopen(kernelslist_location.c_str(), "a");
+      kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "a");
       // This will be a relative path to the traces file
-      sprintf(buffer, "kernel-%d.trace%s", kernelid,
+      sprintf(buffer, "kernel-%d.trace%s", ctx_kernelid[ctx],
               xz_compress_trace ? ".xz" : "");
       if (!stop_report) {
         fprintf(kernelsFile, buffer);
@@ -452,7 +442,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       }
       fclose(kernelsFile);
 
-      statsFile = fopen(stats_location.c_str(), "a");
+      statsFile = fopen(ctx_stats_location[ctx].c_str(), "a");
       unsigned blocks = p->gridDimX * p->gridDimY * p->gridDimZ;
       unsigned threads = p->blockDimX * p->blockDimY * p->blockDimZ;
 
@@ -463,7 +453,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
 
       fclose(statsFile);
 
-      kernelid++;
+      ctx_kernelid[ctx]++;
       recv_thread_receiving = true;
 
     } else {
@@ -498,7 +488,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
           reported_dynamic_instr_counter - old_total_reported_insts;
       old_total_reported_insts = reported_dynamic_instr_counter;
 
-      statsFile = fopen(stats_location.c_str(), "a");
+      statsFile = fopen(ctx_stats_location[ctx].c_str(), "a");
       fprintf(statsFile, "%d,%d", total_insts_per_kernel,
               reported_insts_per_kernel);
       fprintf(statsFile, "\n");
@@ -513,7 +503,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       }
 
       if (active_from_start && dynamic_kernel_limit_end &&
-          kernelid > dynamic_kernel_limit_end)
+          kernelid[ctx] > dynamic_kernel_limit_end)
         active_region = false;
     }
   } else if (cbid == API_CUDA_cuProfilerStart && is_exit) {
@@ -735,4 +725,14 @@ void nvbit_at_ctx_term(CUcontext ctx) {
     recv_thread_started = false;
     pthread_join(recv_thread, NULL);
   }
+}
+
+void nvbit_at_ctx_init(CUcontext ctx)
+{
+  // Everytime we init a context, add the foldername and kernelid to the set
+  std::string tmp_kernelslist = user_folder + "/kernelslist_ctx_" + std::to_string((uint64_t)ctx);
+  ctx_foldername[ctx] = tmp_kernelslist;
+  std::string tmp_stats = user_folder + "/stats_ctx_" + std::to_string((uint64_t)ctx);
+  ctx_stats_location[ctx] = tmp_stats;
+  ctx_kernelid[ctx] = 1;
 }

--- a/util/tracer_nvbit/tracer_tool/traces-processing/Makefile
+++ b/util/tracer_nvbit/tracer_tool/traces-processing/Makefile
@@ -1,7 +1,7 @@
 TARGET := post-traces-processing
 
 $(TARGET): post-traces-processing.cpp
-	g++ -std=c++14 -O3 -g -o $@ $^
+	g++ -std=c++17 -O3 -g -o $@ $^
 
 run: $(TARGET)
 	./$(TARGET)

--- a/util/tracer_nvbit/tracer_tool/traces-processing/post-traces-processing.cpp
+++ b/util/tracer_nvbit/tracer_tool/traces-processing/post-traces-processing.cpp
@@ -119,7 +119,8 @@ int main(int argc, char **argv) {
   {
     for (const auto & entry : std::filesystem::directory_iterator(p))
     {
-      if (entry.path().filename().find("kernelslist") != std::string::npos)
+      std::string filename = entry.path().filename();
+      if (filename.find("kernelslist") != std::string::npos)
       {
         kernelslist_list.push_back(entry.path().string());
       }
@@ -136,20 +137,24 @@ int main(int argc, char **argv) {
   }
 
   for (auto kernellist_filepath : kernelslist_list){
-    ifs.open(kernellist_filepath.c_str());
-    ofs.open((string(kernellist_filepath) + ".g").c_str());
+    string directory(kernellist_filepath);
+    const size_t last_slash_idx = directory.rfind('/');
+    if (std::string::npos != last_slash_idx) {
+      directory = directory.substr(0, last_slash_idx);
+    }
 
+    ifs.open(kernellist_filepath.c_str());
+    // If we have only one context, name it kernelslist.g by default
+    if(kernelslist_list.size() == 1 || kernelslist_list[0] == kernellist_filepath)
+      ofs.open((string(directory)+"/kernelslist.g").c_str());
+    else
+      ofs.open((string(kernellist_filepath) + ".g").c_str());
 
     if (!ifs.is_open()) {
       cerr << "Unable to open file: " << kernellist_filepath << endl;
       return 1;
     }
 
-    string directory(kernellist_filepath);
-    const size_t last_slash_idx = directory.rfind('/');
-    if (std::string::npos != last_slash_idx) {
-      directory = directory.substr(0, last_slash_idx);
-    }
 
     string line;
     string filepath;

--- a/util/tracer_nvbit/tracer_tool/traces-processing/post-traces-processing.cpp
+++ b/util/tracer_nvbit/tracer_tool/traces-processing/post-traces-processing.cpp
@@ -13,6 +13,8 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <filesystem>
+
 using namespace std;
 
 struct threadblock_info {
@@ -87,19 +89,21 @@ void group_per_core(const char *filepath);
 int preserved_stdin_fileno;
 int preserved_stdout_fileno;
 
+std::vector<std::string> kernelslist_list;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 int main(int argc, char **argv) {
   string kernellist_filepath;
+  string filepath;
   bool is_per_core;
   if (argc == 1) {
     cerr << "File path is missing\n";
     return 1;
   } else if (argc == 2) {
-    kernellist_filepath = argv[1];
+    filepath = argv[1];
     is_per_core = true;
 
   } else if (argc == 3) {
-    kernellist_filepath = argv[1];
+    filepath = argv[1];
     is_per_core = bool(argv[2]);
   } else {
     cerr << "Too Many Arguemnts!\n";
@@ -109,46 +113,71 @@ int main(int argc, char **argv) {
   ifstream ifs;
   ofstream ofs;
 
-  ifs.open(kernellist_filepath.c_str());
-  ofs.open((string(kernellist_filepath) + ".g").c_str());
-
-  if (!ifs.is_open()) {
-    cerr << "Unable to open file: " << kernellist_filepath << endl;
+  // We can now pass a directory or a file as the input argument 
+  std::filesystem::path p(filepath);
+  if (std::filesystem::is_directory(p))
+  {
+    for (const auto & entry : std::filesystem::directory_iterator(p))
+    {
+      if (entry.path().filename().find("kernelslist") != std::string::npos)
+      {
+        kernelslist_list.push_back(entry.path().string());
+      }
+    }
+  }
+  else if (std::filesystem::is_regular_file(p))
+  {
+    kernelslist_list.push_back(kernellist_filepath);
+  }
+  else
+  {
+    cerr << "Invalid file path\n";
     return 1;
   }
 
-  string directory(kernellist_filepath);
-  const size_t last_slash_idx = directory.rfind('/');
-  if (std::string::npos != last_slash_idx) {
-    directory = directory.substr(0, last_slash_idx);
-  }
+  for (auto kernellist_filepath : kernelslist_list){
+    ifs.open(kernellist_filepath.c_str());
+    ofs.open((string(kernellist_filepath) + ".g").c_str());
 
-  string line;
-  string filepath;
-  while (!ifs.eof()) {
-    getline(ifs, line);
-    if (line.empty())
-      continue;
-    else if (line.substr(0, 6) == "Memcpy") {
-      ofs << line << endl;
-    } else if (line.substr(0, 6) == "kernel") {
-      filepath = directory + "/" + line;
-      group_per_block(filepath.c_str());
 
-      int _l = line.length();
-      if (_l > 3 && line.substr(_l - 3, 3) == ".xz") {
-        ofs << line.substr(0, _l - 3) << "g.xz" << endl;
-      } else {
-        ofs << line + "g" << endl;
-      }
-    } else {
-      cerr << "Undefined command: " << line << endl;
+    if (!ifs.is_open()) {
+      cerr << "Unable to open file: " << kernellist_filepath << endl;
       return 1;
     }
-  }
 
-  ifs.close();
-  ofs.close();
+    string directory(kernellist_filepath);
+    const size_t last_slash_idx = directory.rfind('/');
+    if (std::string::npos != last_slash_idx) {
+      directory = directory.substr(0, last_slash_idx);
+    }
+
+    string line;
+    string filepath;
+    while (!ifs.eof()) {
+      getline(ifs, line);
+      if (line.empty())
+        continue;
+      else if (line.substr(0, 6) == "Memcpy") {
+        ofs << line << endl;
+      } else if (line.substr(0, 6) == "kernel") {
+        filepath = directory + "/" + line;
+        group_per_block(filepath.c_str());
+
+        int _l = line.length();
+        if (_l > 3 && line.substr(_l - 3, 3) == ".xz") {
+          ofs << line.substr(0, _l - 3) << "g.xz" << endl;
+        } else {
+          ofs << line + "g" << endl;
+        }
+      } else {
+        cerr << "Undefined command: " << line << endl;
+        return 1;
+      }
+    }
+
+    ifs.close();
+    ofs.close();
+  }
   return 0;
 }
 


### PR DESCRIPTION
Updating tracing to output different files indexed by context number. This allows us to not overwrite files when multiple contexts (be it from multiple-threads/processes) are used.

Post-Processing:
   Updated post-processing to also accept folders as inputs (changing the requirements from c++14 to c++17 to use filesystem)
   The first found kernelslist file will be renamed using the default kernelslist.g name (thus no need to change run_simulations.py)

We can test several contexts by doing something like
`seq 10 | parallel -N0 'LD_PRELOAD=../../../tracer_tool/tracer_tool.so ./vectoradd'
` 

