### PR TITLE
add Kernel ranges option

### DIFF
--- a/util/tracer_nvbit/run_hw_trace.py
+++ b/util/tracer_nvbit/run_hw_trace.py
@@ -125,12 +125,14 @@ for bench in benchmarks:
             exec_path = ". " + exec_path
 
             if options.kernel_number > 0:
-                os.environ["DYNAMIC_KERNEL_LIMIT_END"] = str(options.kernel_number)
+                sh_contents +=  ('\nexport DYNAMIC_KERNEL_RANGE="0-'+str(options.kernel_number)+'"\n')
             else:
-                os.environ["DYNAMIC_KERNEL_LIMIT_END"] = "50"
+                sh_contents +=  ('\nexport DYNAMIC_KERNEL_RANGE="0-'+str(50)+'"\n')
         else:
             if options.kernel_number > 0:
-                os.environ["DYNAMIC_KERNEL_LIMIT_END"] = str(options.kernel_number)
+                sh_contents +=  ('\nexport DYNAMIC_KERNEL_RANGE="0-'+str(options.kernel_number)+'"\n')
+            else:
+                sh_contents +=  ('\nexport DYNAMIC_KERNEL_RANGE=""\n')
 
         # first we generate the traces (.trace and kernelslist files)
         # then, we do post-processing for the traces and generate (.traceg and kernelslist.g files)
@@ -141,7 +143,7 @@ for bench in benchmarks:
             + '"; export CUDA_VISIBLE_DEVICES="'
             + options.device_num
             + '" ; '
-            + "\nexport DYNAMIC_KERNEL_LIMIT_START=0; export DYNAMIC_KERNEL_LIMIT_END=0;\n"
+            + "\nrm -f traces/*"
             + "\nexport TRACES_FOLDER="
             + this_run_dir
             + "; CUDA_INJECTION64_PATH="

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -18,6 +18,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <vector>
+#include <regex>
 /* every tool needs to include this once */
 #include "nvbit_tool.h"
 
@@ -90,6 +91,7 @@ std::string kernel_ranges = "";
 struct KernelRange {
   uint64_t start;
   uint64_t end; // UINT64_MAX means open-ended
+  std::vector<std::regex> kernel_name_regexes;  // Vector of regexes for multiple patterns
 };
 std::vector<KernelRange> g_kernel_ranges;
 uint64_t g_max_kernel_id = 0;
@@ -102,41 +104,86 @@ void parse_kernel_ranges_from_env() {
       g_kernel_ranges.push_back({0, 0});  // 0 end = trace all
       return;
   }
-
   std::istringstream iss(env_var);
-  std::string token;
-  while (iss >> token) {
-      size_t dash_pos = token.find('-');
-      if (dash_pos != std::string::npos) {
-          std::string start_str = token.substr(0, dash_pos);
-          std::string end_str = token.substr(dash_pos + 1);
+    std::string token;
+    while (iss >> token) {
+        size_t dash_pos = token.find('-');
+        size_t regex_pos = token.find('@');  // kernel name indicated by @
+        uint64_t start = 0;
+        uint64_t end = 0;
 
-          uint64_t start = std::stoull(start_str);
-          uint64_t end = 0;
-          if (!end_str.empty()) {
-              end = std::stoull(end_str);
-          }
+        if (regex_pos != std::string::npos) {
+            // Kernel name range with regex
+            std::string range_part = token.substr(0, regex_pos);
+            std::string regex_str = token.substr(regex_pos + 1);
 
-          g_kernel_ranges.push_back({start, end});
-          if (end != 0 && end > g_max_kernel_id)
-              g_max_kernel_id = end;
-      } else {
-          uint64_t single = std::stoull(token);
-          g_kernel_ranges.push_back({single, single});
-          if (single > g_max_kernel_id)
-              g_max_kernel_id = single;
-      }
-  }
+          
+
+            // Parse the range part for start and end
+            size_t dash_pos_range = range_part.find('-');
+            if (dash_pos_range != std::string::npos) {
+                start = std::stoull(range_part.substr(0, dash_pos_range));
+                end = std::stoull(range_part.substr(dash_pos_range + 1));
+            } else {
+                start = std::stoull(range_part);
+                end = start;
+            }
+
+            // Split multiple regexes by commas
+            std::vector<std::string> regex_strings;
+            std::istringstream regex_stream(regex_str);
+            std::string regex_token;
+            while (std::getline(regex_stream, regex_token, ',')) {
+                try {
+                    g_kernel_ranges.push_back({start, end, {std::regex(regex_token)}});
+                } catch (const std::regex_error& e) {
+                    std::cerr << "Invalid regex: " << regex_token << std::endl;
+                }
+            }
+        } else {
+            // Normal range without kernel name regex
+            size_t dash_pos_range = token.find('-');
+
+            if (dash_pos_range != std::string::npos) {
+                start = std::stoull(token.substr(0, dash_pos_range));
+                end = std::stoull(token.substr(dash_pos_range + 1));
+            } else {
+                start = std::stoull(token);
+                end = start;
+            }
+
+            g_kernel_ranges.push_back({start, end, {}});
+        }
+
+        // Update max kernel ID if needed
+        if (end > g_max_kernel_id) {
+            g_max_kernel_id = end;
+        }
+    }
+
+
 }
 
-bool should_trace_kernel(uint64_t kernel_id) {
+bool should_trace_kernel(uint64_t kernel_id, const std::string& kernel_name) {
   for (const auto& range : g_kernel_ranges) {
-      if (range.end == 0) {
-          if (kernel_id >= range.start)
-              return true;
-      } else if (kernel_id >= range.start && kernel_id <= range.end) {
-          return true;
-      }
+    // Check range for kernel ID
+    if (range.end == 0) {
+        if (kernel_id >= range.start) {
+            // Match any of the regexes for this range
+            for (const auto& regex : range.kernel_name_regexes) {
+                if (std::regex_match(kernel_name, regex)) {
+                    return true;
+                }
+            }
+        }
+    } else if (kernel_id >= range.start && kernel_id <= range.end) {
+        // Match any of the regexes for this range
+        for (const auto& regex : range.kernel_name_regexes) {
+            if (std::regex_match(kernel_name, regex)) {
+                return true;
+            }
+        }
+    }
   }
   return false;
 }
@@ -218,7 +265,7 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
     const std::vector<Instr *> &instrs = nvbit_get_instrs(ctx, f);
     if (verbose) {
       printf("Inspecting function %s at address 0x%lx\n",
-             nvbit_get_func_name(ctx, f), nvbit_get_func_addr(ctx,f), true);
+             nvbit_get_func_name(ctx, f), nvbit_get_func_addr(ctx,f));
     }
 
     uint32_t cnt = 0;
@@ -317,8 +364,8 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           nvbit_add_call_arg_const_val32(instr, (int)instr->getSize());
         } else {
           nvbit_add_call_arg_const_val32(instr, 0);
-          nvbit_add_call_arg_const_val64(instr, -1);
-          nvbit_add_call_arg_const_val32(instr, -1);
+          nvbit_add_call_arg_const_val64(instr, static_cast<uint64_t>(-1));
+          nvbit_add_call_arg_const_val32(instr, static_cast<uint32_t>(-1));
         }
 
         /* reg info */
@@ -327,7 +374,7 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           nvbit_add_call_arg_const_val32(instr, src_oprd[i]);
         }
         for (int i = srcNum; i < MAX_SRC; i++) {
-          nvbit_add_call_arg_const_val32(instr, -1);
+          nvbit_add_call_arg_const_val32(instr, static_cast<uint32_t>(-1));
         }
         nvbit_add_call_arg_const_val32(instr, srcNum);
 
@@ -363,10 +410,10 @@ __global__ void flush_channel() {
   channel_dev.flush();
 }
 
-static FILE *resultsFile = NULL;
+// static FILE *resultsFile = NULL;
 static FILE *kernelsFile = NULL;
 static FILE *statsFile = NULL;
-static int kernelid = 1;
+// static int kernelid = 1;
 static bool first_call = true;
 
 unsigned old_total_insts = 0;
@@ -404,7 +451,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       cuMemcpyHtoD_v2_params *p = (cuMemcpyHtoD_v2_params *)params;
       char buffer[1024];
       kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "a");
-      sprintf(buffer, "MemcpyHtoD,0x%016lx,%lld", p->dstDevice, p->ByteCount);
+      sprintf(buffer, "MemcpyHtoD,0x%016llx,%llu", p->dstDevice, p->ByteCount);
       fprintf(kernelsFile, buffer);
       fprintf(kernelsFile, "\n");
       fclose(kernelsFile);
@@ -413,8 +460,10 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
   } else if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
              cbid == API_CUDA_cuLaunchKernel) {
     cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
+    std::string fun_name = std::string (nvbit_get_func_name(ctx, p->f, true));
     if (!is_exit) {
-      if (active_from_start && should_trace_kernel(ctx_kernelid[ctx]))
+      
+      if (active_from_start && should_trace_kernel(ctx_kernelid[ctx],fun_name))
         active_region = true;
 
       if (terminate_after_limit_number_of_kernels_reached &&
@@ -561,7 +610,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         }
       }
 
-      if (active_from_start && !should_trace_kernel(ctx_kernelid[ctx]))
+      if (active_from_start && !should_trace_kernel(ctx_kernelid[ctx],fun_name))
         active_region = false;
     }
   } else if (cbid == API_CUDA_cuProfilerStart && is_exit) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -205,14 +205,14 @@ void nvbit_at_init() {
               "The target binary must be compiled with -lineinfo or "
               "--generate-line-info");
   GET_VAR_STR(kernel_ranges, "DYNAMIC_KERNEL_RANGE",
-      "Specify kernel IDs or ranges to trace.\n"
-      "Format: space-separated list of IDs or ranges.\n"
-      "  - Single ID: e.g., \"2\" traces only kernel 2.\n"
-      "  - Range: e.g., \"5-8\" traces kernels 5 through 8 inclusive.\n"
-      "  - Open-ended range: e.g., \"10-\" traces from kernel 10 onward.\n"
-      "  - Multiple ranges: e.g., \"2 5-8 10-\".\n"
-      "If unset or empty, all kernels are traced from the beginning.");
-  GET_VAR_INT(
+  "Specify kernel IDs or ranges to trace. Format:\n"
+  "  - Single ID:       \"2\" traces only kernel 2.\n"
+  "  - Range:           \"5-8\" traces kernels 5 through 8 (inclusive).\n"
+  "  - Open-ended:      \"10-\" traces from kernel 10 onward.\n"
+  "  - Multiple ranges: \"2 5-8 10-\" (space-separated).\n"
+  "  - With regex:      \"5-8@kernel_a.*,kernel_b.*\" traces kernels 5–8 with matching names.\n"
+  "If unset or empty, all kernels will be traced from the beginning.");
+GET_VAR_INT(
       active_from_start, "ACTIVE_FROM_START", 1,
       "Start instruction tracing from start or wait for cuProfilerStart "
       "and cuProfilerStop. If set to 0, DYNAMIC_KERNEL_RANGE options have no "

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -85,6 +85,64 @@ uint64_t dynamic_kernel_limit_start =
     0;                                 // 0 means start from the begging kernel
 uint64_t dynamic_kernel_limit_end = 0; // 0 means no limit
 
+std::string kernel_ranges = "";
+
+struct KernelRange {
+  uint64_t start;
+  uint64_t end; // UINT64_MAX means open-ended
+};
+std::vector<KernelRange> g_kernel_ranges;
+uint64_t g_max_kernel_id = 0;
+void parse_kernel_ranges_from_env() {
+  g_kernel_ranges.clear();
+  g_max_kernel_id = 0;
+
+  const char* env_var = std::getenv("KERNEL_RANGES");
+  if (!env_var || std::string(env_var).empty()) {
+      g_kernel_ranges.push_back({0, 0});  // 0 end = trace all
+      printf("-------------------\nhere");
+      return;
+  }
+
+  std::istringstream iss(env_var);
+  std::string token;
+  while (iss >> token) {
+      size_t dash_pos = token.find('-');
+      if (dash_pos != std::string::npos) {
+          std::string start_str = token.substr(0, dash_pos);
+          std::string end_str = token.substr(dash_pos + 1);
+
+          uint64_t start = std::stoull(start_str);
+          uint64_t end = 0;
+          if (!end_str.empty()) {
+              end = std::stoull(end_str);
+          }
+
+          g_kernel_ranges.push_back({start, end});
+          if (end != 0 && end > g_max_kernel_id)
+              g_max_kernel_id = end;
+      } else {
+          uint64_t single = std::stoull(token);
+          g_kernel_ranges.push_back({single, single});
+          if (single > g_max_kernel_id)
+              g_max_kernel_id = single;
+      }
+  }
+}
+
+bool should_trace_kernel(uint64_t kernel_id) {
+  for (const auto& range : g_kernel_ranges) {
+      if (range.end == 0) {
+          if (kernel_id >= range.start)
+              return true;
+      } else if (kernel_id >= range.start && kernel_id <= range.end) {
+          return true;
+      }
+  }
+  return false;
+}
+
+
 enum address_format { list_all = 0, base_stride = 1, base_delta = 2 };
 
 void nvbit_at_init() {
@@ -100,15 +158,18 @@ void nvbit_at_init() {
               "Include source code line info at the start of each traced line. "
               "The target binary must be compiled with -lineinfo or "
               "--generate-line-info");
-  GET_VAR_INT(dynamic_kernel_limit_end, "DYNAMIC_KERNEL_LIMIT_END", 0,
-              "Limit of the number kernel to be printed, 0 means no limit");
-  GET_VAR_INT(dynamic_kernel_limit_start, "DYNAMIC_KERNEL_LIMIT_START", 0,
-              "start to report kernel from this kernel id, 0 means starts from "
-              "the beginning, i.e. first kernel");
+  GET_VAR_STR(kernel_ranges, "DYNAMIC_KERNEL_RANGE",
+      "Specify kernel IDs or ranges to trace.\n"
+      "Format: space-separated list of IDs or ranges.\n"
+      "  - Single ID: e.g., \"2\" traces only kernel 2.\n"
+      "  - Range: e.g., \"5-8\" traces kernels 5 through 8 inclusive.\n"
+      "  - Open-ended range: e.g., \"10-\" traces from kernel 10 onward.\n"
+      "  - Multiple ranges: e.g., \"2 5-8 10-\".\n"
+      "If unset or empty, all kernels are traced from the beginning.");
   GET_VAR_INT(
       active_from_start, "ACTIVE_FROM_START", 1,
       "Start instruction tracing from start or wait for cuProfilerStart "
-      "and cuProfilerStop. If set to 0, DYNAMIC_KERNEL_LIMIT options have no "
+      "and cuProfilerStop. If set to 0, DYNAMIC_KERNEL_RANGE options have no "
       "effect");
   GET_VAR_INT(verbose, "TOOL_VERBOSE", 0, "Enable verbosity inside the tool");
   GET_VAR_INT(enable_compress, "TOOL_COMPRESS", 1, "Enable traces compression");
@@ -132,6 +193,8 @@ void nvbit_at_init() {
   char * usr_defined_folder = std::getenv("TRACES_FOLDER");
   if (usr_defined_folder != NULL)
     user_folder = usr_defined_folder;
+  parse_kernel_ranges_from_env();
+  printf("090909090909090----------==============\n");
 
 }
 
@@ -331,13 +394,6 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
       }
     }
 
-    if (active_from_start && !dynamic_kernel_limit_start ||
-        dynamic_kernel_limit_start == 1)
-      active_region = true;
-    else {
-      if (active_from_start)
-        active_region = false;
-    }
 
     kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "w");
     statsFile = fopen(ctx_stats_location[ctx].c_str(), "w");
@@ -362,15 +418,14 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
   } else if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
              cbid == API_CUDA_cuLaunchKernel) {
     cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
-
+              printf("API_CUDA_cuLaunchKernel************\n");
     if (!is_exit) {
-      if (active_from_start && dynamic_kernel_limit_start &&
-          ctx_kernelid[ctx] == dynamic_kernel_limit_start)
+      if (active_from_start && should_trace_kernel(ctx_kernelid[ctx]))
         active_region = true;
 
       if (terminate_after_limit_number_of_kernels_reached &&
-          dynamic_kernel_limit_end != 0 &&
-          ctx_kernelid[ctx] > dynamic_kernel_limit_end) {
+          g_max_kernel_id != 0 &&
+          ctx_kernelid[ctx] > g_max_kernel_id) {
         exit(0);
       }
 
@@ -512,8 +567,7 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         }
       }
 
-      if (active_from_start && dynamic_kernel_limit_end &&
-          ctx_kernelid[ctx] > dynamic_kernel_limit_end)
+      if (active_from_start && !should_trace_kernel(ctx_kernelid[ctx]))
         active_region = false;
     }
   } else if (cbid == API_CUDA_cuProfilerStart && is_exit) {

--- a/util/tracer_nvbit/tracer_tool/tracer_tool.cu
+++ b/util/tracer_nvbit/tracer_tool/tracer_tool.cu
@@ -97,10 +97,9 @@ void parse_kernel_ranges_from_env() {
   g_kernel_ranges.clear();
   g_max_kernel_id = 0;
 
-  const char* env_var = std::getenv("KERNEL_RANGES");
+  const char* env_var = std::getenv("DYNAMIC_KERNEL_RANGE");
   if (!env_var || std::string(env_var).empty()) {
       g_kernel_ranges.push_back({0, 0});  // 0 end = trace all
-      printf("-------------------\nhere");
       return;
   }
 
@@ -187,14 +186,12 @@ void nvbit_at_init() {
   std::string pad(100, '-');
   printf("%s\n", pad.c_str());
 
-  if (active_from_start == 0) {
-    active_region = false;
-  }
+  
+  active_region = false;
   char * usr_defined_folder = std::getenv("TRACES_FOLDER");
   if (usr_defined_folder != NULL)
     user_folder = usr_defined_folder;
   parse_kernel_ranges_from_env();
-  printf("090909090909090----------==============\n");
 
 }
 
@@ -393,8 +390,6 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
         return;
       }
     }
-
-
     kernelsFile = fopen(ctx_kernelslist[ctx].c_str(), "w");
     statsFile = fopen(ctx_stats_location[ctx].c_str(), "w");
     fprintf(statsFile,
@@ -418,7 +413,6 @@ void nvbit_at_cuda_event(CUcontext ctx, int is_exit, nvbit_api_cuda_t cbid,
   } else if (cbid == API_CUDA_cuLaunchKernel_ptsz ||
              cbid == API_CUDA_cuLaunchKernel) {
     cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
-              printf("API_CUDA_cuLaunchKernel************\n");
     if (!is_exit) {
       if (active_from_start && should_trace_kernel(ctx_kernelid[ctx]))
         active_region = true;


### PR DESCRIPTION
This change introduces support for selecting specific kernel IDs or ranges to trace via the DYNAMIC_KERNEL_RANGE environment variable. It also supports optional regular expression filtering by kernel name.

Usage
Set DYNAMIC_KERNEL_RANGE to a space-separated list of kernel IDs or ranges, optionally combined with regex filters:

Single ID:
"2" traces only kernel 2.

Range:
"5-8" traces kernels 5 through 8 (inclusive).

Open-ended range:
"10-" traces from kernel 10 onward.

Multiple ranges:
"2 5-8 10-" traces kernel 2, 5 through 8, and from 10 onward.

With kernel name regex:
"5-8@kernelA.*" traces kernels 5 to 8 only if the kernel name matches the regex kernelA.*.
"10-@.*fft.*" traces from kernel 10 onward, but only if the name matches .*fft.*.

Multiple regex filters (comma-separated):
"5-8@kernelA.*,kernelB.*" matches any kernel between 5 and 8 whose name matches either regex.

If DYNAMIC_KERNEL_RANGE is unset or empty, all kernels are traced from the beginning.