### PR TITLE
Fix stats archive in CIs

### DIFF
--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -69,7 +69,7 @@ jobs:
           | tee turing-ubench-sass-latest2.csv && mv turing-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv ./statistics-archive/ubench/turing-ubench-sass-latest.csv
           ./util/plotting/merge-stats.py -R -c ./statistics-archive/ubench/ampere-ubench-sass-latest.csv,ampere-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv \
           | tee ampere-ubench-sass-latest2.csv && mv ampere-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv ./statistics-archive/ubench/ampere-ubench-sass-latest.csv
-          if [[ ${{ github.event_name }} == 'push' ]]; then
+          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
             git -C ./statistics-archive add --all
             git -C ./statistics-archive commit \
             -m "Jenkins automated checkin git_${GITHUB_REF}"_"$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT Build:$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT" || echo "No Changes."

--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -69,10 +69,12 @@ jobs:
           | tee turing-ubench-sass-latest2.csv && mv turing-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv ./statistics-archive/ubench/turing-ubench-sass-latest.csv
           ./util/plotting/merge-stats.py -R -c ./statistics-archive/ubench/ampere-ubench-sass-latest.csv,ampere-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv \
           | tee ampere-ubench-sass-latest2.csv && mv ampere-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv ./statistics-archive/ubench/ampere-ubench-sass-latest.csv
-          git -C ./statistics-archive add --all
-          git -C ./statistics-archive commit \
-          -m "Jenkins automated checkin git_${GITHUB_REF}"_"$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT Build:$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT" || echo "No Changes."
-          git -C ./statistics-archive push -u origin git_${GITHUB_REF}"_"$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT
+          if [[ ${{ github.event_name }} == 'push' ]]; then
+            git -C ./statistics-archive add --all
+            git -C ./statistics-archive commit \
+            -m "Jenkins automated checkin git_${GITHUB_REF}"_"$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT Build:$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT" || echo "No Changes."
+            git -C ./statistics-archive push -u origin ${GITHUB_REF}
+          fi
       - name: Correlate Ubench
         run: |
           source ./env-setup/12.4_env_setup.sh

--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -43,7 +43,7 @@ jobs:
           ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C QV100-SASS -T ~/../common/accel-sim/traces/volta-tesla-v100/latest/ -N sass-short-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT
           ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C RTX2060-SASS -T ~/../common/accel-sim/traces/turing-rtx2060/latest/ -N sass-short-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT
           ./util/job_launching/run_simulations.py -B rodinia_2.0-ft,GPU_Microbenchmark -C RTX3070-SASS -T ~/../common/accel-sim/traces/ampere-rtx3070/latest/ -N sass-short-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT
-          ./util/job_launching/monitor_func_test.py -v -s stats-per-app-sass.csv -N sass-short-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT
+          ./util/job_launching/monitor_func_test.py -v -s --sleep_time 300 stats-per-app-sass.csv -N sass-short-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT
       - name: Archive Stats
         run: |
           source ./env-setup/12.4_env_setup.sh
@@ -85,6 +85,10 @@ jobs:
           ./util/plotting/plot-correlation.py -c ./ampere-ubench-sass-latest2.csv -H ./hw_run/AMPERE-RTX3070/11.2/ | tee ampere-ubench-correl.txt
           ssh ghci@tgrogers-pc01 mkdir -p /home/ghci/accel-sim/correl/git_${GITHUB_REF}"_"$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT/
           rsync --delete -r ./util/plotting/correl-html/ ghci@tgrogers-pc01:/home/ghci/accel-sim/correl/git_${GITHUB_REF}"_"$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT/
+          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+            rm -rf /scratch/tgrogers-disk01/a/tgrghci/ci/accel_sim_framework/lastDevSuccess
+            mv $PWD /scratch/tgrogers-disk01/a/tgrghci/ci/accel_sim_framework/lastDevSuccess
+          fi
           BODY="Github CI - Build $GITHUB_REF SUCCESS.
           Action link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           Branch/PR Name: $GITHUB_REF_NAME


### PR DESCRIPTION
The branch name was related to the run ID, which is changing every time. Result in creating a new branch every run, which is not the intended behavior. This fixes the stats archive branch name to the branch name that is performing CI. 

And I limited the archive for push events. A PR after a merge is considered a push event. 
I don't think it's meaningful to archive unstable PR checks. But please speak up if you disagree.