### PR TITLE
fix CI branch name

### DIFF
--- a/.github/workflows/long-tests.yml
+++ b/.github/workflows/long-tests.yml
@@ -49,8 +49,9 @@ jobs:
           source ./env-setup/12.4_env_setup.sh
           rm -rf ./statistics-archive
           git clone git@github.com:accel-sim/statistics-archive.git
+          BRANCH_NAME=${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}
           # either create a new branch or check it out if it already exists
-          git -C ./statistics-archive checkout ${GITHUB_REF} 2>/dev/null || git -C ./statistics-archive checkout -b ${GITHUB_REF}
+          git -C ./statistics-archive checkout $BRANCH_NAME 2>/dev/null || git -C ./statistics-archive checkout -b $BRANCH_NAME
           ./util/job_launching/get_stats.py -k -K -R -B GPU_Microbenchmark -C QV100-SASS -A | tee v100-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv
           ./util/job_launching/get_stats.py -k -K -R -B GPU_Microbenchmark -C RTX2060-SASS -A | tee turing-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv
           ./util/job_launching/get_stats.py -k -K -R -B GPU_Microbenchmark -C RTX3070-SASS -A | tee ampere-ubench-sass-$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT.csv
@@ -72,8 +73,8 @@ jobs:
           if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
             git -C ./statistics-archive add --all
             git -C ./statistics-archive commit \
-            -m "Jenkins automated checkin ${GITHUB_REF} Build:$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT" || echo "No Changes."
-            git -C ./statistics-archive push -u origin ${GITHUB_REF}
+            -m "Jenkins automated checkin $BRANCH_NAME Build:$GITHUB_RUN_NUMBER"_"$GITHUB_RUN_ATTEMPT" || echo "No Changes."
+            git -C ./statistics-archive push -u origin $BRANCH_NAME
           fi
       - name: Correlate Ubench
         run: |


### PR DESCRIPTION
It will look like:
accel-sim/accel-sim-framework/dev

which matches the original format from Jenkins. However. It uses "Acce-Sim" (uppercase) for some reason. 
https://github.com/accel-sim/statistics-archive

Double check it and make sure I have all the names changes. 