### PR TITLE
[Fix] Fix potential deadlock caused by the last `EXIT` instruction.

### DIFF
--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -585,7 +585,7 @@ const warp_inst_t *trace_shader_core_ctx::get_next_inst(unsigned warp_id,
   trace_shd_warp_t *m_trace_warp =
       static_cast<trace_shd_warp_t *>(m_warp[warp_id]);
   const trace_warp_inst_t *ret = m_trace_warp->get_next_trace_inst();
-  if (m_trace_warp->trace_done()) {
+  if (ret == NULL && m_trace_warp->trace_done()) {
     if (!m_warp[warp_id]->inst_in_pipeline() &&
         m_warp[warp_id]->stores_done() &&
         !m_scoreboard->pendingWrites(warp_id)) {


### PR DESCRIPTION
Potentional deadlock may occur in `trace_shader_core_ctx::get_next_inst`. Once the last instruction is `EXIT`, and no more instructions in traces, `m_trace_warp->trace_done()` will be evaluated to be `true`. Since the number of instruction in pipeline will be increased at `shader_core_ctx::decode()` in gpgpu-sim, the `!m_warp[warp_id]->inst_in_pipeline()` will also be evaluated to be true. And finally, all threads will be set to completed, and cause a deadlock for issue stage.

Increasing `inst_in_pipeline` with in `decode()` function of gpgpu-sim:

https://github.com/accel-sim/gpgpu-sim_distribution/blob/b18ee3977962921c49fabe06d26ae19694497c26/src/gpgpu-sim/shader.cc#L896

Functional done will check if all threads have done:

https://github.com/accel-sim/gpgpu-sim_distribution/blob/b18ee3977962921c49fabe06d26ae19694497c26/src/gpgpu-sim/shader.cc#L4085C1-L4087C2

Issue stage will check if the warp is waiting, and one of the condition is whether it is `functional_done`:

https://github.com/accel-sim/gpgpu-sim_distribution/blob/b18ee3977962921c49fabe06d26ae19694497c26/src/gpgpu-sim/shader.cc#L4093C1-L4114C2

This PR provide a walk around for this situation. Before we check `trace_done()`, we should firstly check if `get_next_trace_inst` returns a valid instruction.