### PR TITLE
Fix indentation in procman.py

### DIFF
--- a/util/job_launching/procman.py
+++ b/util/job_launching/procman.py
@@ -197,7 +197,7 @@ class ProcMan:
                 continue
             for child in p.children(recursive=True):
                 os.kill(child.pid, 9)
-        os.kill(activeJob.procId, 9)
+            os.kill(activeJob.procId, 9)
 
     def tick(self):
         if self.tickingProcess == None:


### PR DESCRIPTION
Missing indentation in `procman.py`. Script does not correctly kill jobs.

Credit: this issue was first found by Wu, a student taking computer architecture class at UBC. He reported this bug to the TA.