### PR TITLE
Add sm_89 (Ada) support and RTX 4060 Laptop config

### DIFF
--- a/gpu-simulator/ISA_Def/ampere_opcode.h
+++ b/gpu-simulator/ISA_Def/ampere_opcode.h
@@ -11,6 +11,7 @@
 
 #define AMPERE_RTX_BINART_VERSION 86
 #define AMPERE_A100_BINART_VERSION 80
+#define ADA_RTX_BINART_VERSION 89
 
 // TO DO: moving this to a yml or def files
 

--- a/gpu-simulator/configs/tested-cfgs/SM89_RTX4060_LAPTOP/trace.config
+++ b/gpu-simulator/configs/tested-cfgs/SM89_RTX4060_LAPTOP/trace.config
@@ -1,0 +1,23 @@
+-trace_opcode_latency_initiation_int 2,2
+-trace_opcode_latency_initiation_sp 2,1
+-trace_opcode_latency_initiation_dp 64,64
+-trace_opcode_latency_initiation_sfu 21,8
+-trace_opcode_latency_initiation_tensor 32,32
+
+#execute branch insts on spec unit 1
+#<enabled>,<num_units>,<max_latency>,<ID_OC_SPEC>,<OC_EX_SPEC>,<NAME>
+-specialized_unit_1 1,4,4,4,4,BRA
+-trace_opcode_latency_initiation_spec_op_1 4,4
+
+#TEX unit, make fixed latency for all tex insts
+-specialized_unit_2 1,4,200,4,4,TEX
+-trace_opcode_latency_initiation_spec_op_2 200,4
+
+#tensor unit
+-specialized_unit_3 1,4,32,4,4,TENSOR
+-trace_opcode_latency_initiation_spec_op_3 32,32
+
+#UDP unit, for turing and above
+#for more info about UDP, see https://www.hotchips.org/hc31/HC31_2.12_NVIDIA_final.pdf
+-specialized_unit_4 1,4,4,4,4,UDP
+-trace_opcode_latency_initiation_spec_op_4 4,1

--- a/gpu-simulator/trace-driven/trace_driven.cc
+++ b/gpu-simulator/trace-driven/trace_driven.cc
@@ -103,7 +103,8 @@ trace_kernel_info_t::trace_kernel_info_t(dim3 gridDim, dim3 blockDim,
 
   // resolve the binary version
   if (kernel_trace_info->binary_verion == AMPERE_RTX_BINART_VERSION ||
-      kernel_trace_info->binary_verion == AMPERE_A100_BINART_VERSION)
+      kernel_trace_info->binary_verion == AMPERE_A100_BINART_VERSION ||
+      kernel_trace_info->binary_verion == ADA_RTX_BINART_VERSION)
     OpcodeMap = &Ampere_OpcodeMap;
   else if (kernel_trace_info->binary_verion == VOLTA_BINART_VERSION)
     OpcodeMap = &Volta_OpcodeMap;

--- a/util/job_launching/configs/define-standard-cfgs.yml
+++ b/util/job_launching/configs/define-standard-cfgs.yml
@@ -15,6 +15,10 @@ TITANK:
 RTX3070:
     base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM86_RTX3070/gpgpusim.config"
 
+#Ada RTX 4060 Laptop
+RTX4060:
+    base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM89_RTX4060_LAPTOP/gpgpusim.config"
+
 #Turing
 RTX2060:
     base_file: "$GPGPUSIM_ROOT/configs/tested-cfgs/SM75_RTX2060/gpgpusim.config"


### PR DESCRIPTION
- ampere_opcode.h: define ADA_RTX_BINART_VERSION 89
- trace_driven.cc: map binary version 89 to Ampere opcode table (Ada/sm_89 shares the Ampere SASS ISA)
- add SM89_RTX4060_LAPTOP trace.config and RTX4060 yml entry

The matching gpgpusim.config lives in the gpgpu-sim_distribution submodule.