### PR TITLE
Correct the AccelWattch author order in the citation metadata

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -41,8 +41,8 @@
 
 % ---- Add if you use the power model ----
 @inproceedings{accelwattch2021,
-  author    = {Vijay Kandiah and Scott Peverelle and Mahmoud Khairy and Amogh Manjunath and
-               Junrui Pan and Timothy G. Rogers and Tor M. Aamodt and Nikos Hardavellas},
+  author    = {Vijay Kandiah and Scott Peverelle and Mahmoud Khairy and Junrui Pan and
+               Amogh Manjunath and Timothy G. Rogers and Tor M. Aamodt and Nikos Hardavellas},
   title     = {AccelWattch: A Power Modeling Framework for Modern {GPU}s},
   booktitle = {MICRO},
   year      = {2021},

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -123,10 +123,10 @@ references:
         family-names: Peverelle
       - given-names: Mahmoud
         family-names: Khairy
-      - given-names: Amogh
-        family-names: Manjunath
       - given-names: Junrui
         family-names: Pan
+      - given-names: Amogh
+        family-names: Manjunath
       - given-names: Timothy G.
         family-names: Rogers
       - given-names: Tor M.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ These are **in addition to** the base papers above, not instead of them.
 
 ```bibtex
 @inproceedings{accelwattch2021,
-  author    = {Vijay Kandiah and Scott Peverelle and Mahmoud Khairy and Amogh Manjunath and
-               Junrui Pan and Timothy G. Rogers and Tor M. Aamodt and Nikos Hardavellas},
+  author    = {Vijay Kandiah and Scott Peverelle and Mahmoud Khairy and Junrui Pan and
+               Amogh Manjunath and Timothy G. Rogers and Tor M. Aamodt and Nikos Hardavellas},
   title     = {AccelWattch: A Power Modeling Framework for Modern {GPU}s},
   booktitle = {MICRO},
   year      = {2021},


### PR DESCRIPTION
The MICRO'21 AccelWattch entry has **Amogh Manjunath and Junrui Pan swapped**.

The published order is:

> Vijay Kandiah, Scott Peverelle, Mahmoud Khairy, **Junrui Pan, Amogh Manjunath**, Timothy G. Rogers, Tor M. Aamodt, Nikos Hardavellas

Verified against two independent sources — the Crossref metadata ACM registered for `10.1145/3466752.3480063`, and DBLP. Both agree. (`dl.acm.org` itself returns 403 to non-browser requests, so it could not be read directly.)

## What changed

The entry appears in three places, all corrected:

| File | Note |
|---|---|
| `CITATION.bib` | the cumulative BibTeX set |
| `README.md` | the BibTeX block under "Power modeling" — kept byte-identical to `CITATION.bib` |
| `CITATION.cff` | drives GitHub's **"Cite this repository"** button, so the wrong order was what the sidebar exported |

## Checks

- `cffconvert --validate` passes against CFF schema 1.2.0.
- All five BibTeX entries remain byte-identical between `README.md` and `CITATION.bib`.
- The other four entries were checked against Crossref at the same time and are correct as-is: ISCA'20 (incl. **Zhesheng** Shen), ISPASS'09, and GPUWattch.

## Note on v2.0.0

The `v2.0.0` tag keeps the old order. The tag and `dev` currently point at the same commit, so correcting the release in place would mean force-moving the tag — silently changing the bytes behind `tarball/v2.0.0` under an unchanged version number. Not worth it for a metadata fix; the tag stands as an accurate record of what shipped, and anyone citing from the repo gets the correction.

The project website has already been updated separately and carries the correct order.