### PR TITLE
Set the v2.0.0 release date in the release notes

### DIFF
--- a/release.notes.md
+++ b/release.notes.md
@@ -1,7 +1,7 @@
 
 # Release v2.0.0 — Accel-Sim 2.0 (full Hopper support)
 
-_TBD 2026._
+_Aug 25, 2026._
 
 Accel-Sim 2.0 brings **full NVIDIA Hopper (H100 / H200) support** to the trace-driven
 simulator, modeling the asynchronous, warp-specialized, persistent execution style of


### PR DESCRIPTION
`release.notes.md` still reads `_TBD 2026._` for the v2.0.0 entry, which went out with the release and is now linked from the project website in two places.

v2.0.0 was published **Aug 25, 2026** (`2026-08-25T17:37:42Z`), matching the tag. Formatted to match the date style already used by the older entries in the file.

One-line change; no other `TBD` remains in the file.