### PR TITLE
Revert slurm.sim to the pre-2.0 template (fixes `-l local` launches)

### DIFF
--- a/util/job_launching/slurm.sim
+++ b/util/job_launching/slurm.sim
@@ -8,50 +8,18 @@
 #SBATCH -p REPLACE_QUEUE_NAME
 #SBATCH --mail-type=END,FAIL
 #SBATCH --export=ALL
-#SBATCH --output=/dev/null
-#SBATCH --error=/dev/null
-
-NFS_DIR=REPLACE_SUBDIR
-TMP_DIR=/tmp/${SLURM_JOB_ID}_REPLACE_NAME
-mkdir -p "$TMP_DIR"
-
-# Redirect stdout/stderr into TMP_DIR so they get synced with everything else
-exec > "$TMP_DIR/REPLACE_NAME.o$SLURM_JOB_ID" 2> "$TMP_DIR/REPLACE_NAME.e$SLURM_JOB_ID"
-
-# Periodic sync: copy tmp workdir back to NFS every 5 minutes
-sync_to_nfs() {
-    rsync -a --update "$TMP_DIR/" "$NFS_DIR/"
-}
-
-# Background sync loop — self-terminates if the Slurm job no longer exists
-# (e.g. OOM kill, scancel, node failure). squeue is the authoritative source.
-(
-    while squeue -j $SLURM_JOB_ID &>/dev/null; do
-        sleep 300
-        sync_to_nfs
-    done
-    # Job is gone (OOM/scancel/etc) — final sync and clean up
-    sync_to_nfs && rm -rf "$TMP_DIR"
-) &
-SYNC_PID=$!
+#SBATCH --output=/tmp/REPLACE_NAME.o%j
+#SBATCH --error=/tmp/REPLACE_NAME.e%j
 
 copy_output() {
-    # Kill the background sync loop
-    kill $SYNC_PID 2>/dev/null || true
-    wait $SYNC_PID 2>/dev/null || true
-    # Final sync of all working files (including logs) from tmp to NFS
-    sync_to_nfs
-    # Clean up tmp dir
-    rm -rf "$TMP_DIR"
+    mv /tmp/REPLACE_NAME.e$SLURM_JOB_ID ./REPLACE_NAME.e$SLURM_JOB_ID
+    mv /tmp/REPLACE_NAME.o$SLURM_JOB_ID ./REPLACE_NAME.o$SLURM_JOB_ID
 }
 
-# Convert signals into exits so the EXIT trap handles everything in one place.
-# Do NOT trap cleanup on signals directly — that causes double execution
-# (signal handler runs, then EXIT handler runs again).
-trap 'exit 1' SIGTERM SIGINT
-trap copy_output EXIT
+trap copy_output ERR
 
-# -e: exit on error, -E: ERR traps inherited by functions/subshells
+#citing https://stackoverflow.com/questions/35800082/how-to-trap-err-when-using-set-e-in-bash
+#Setting -E alongside -e makes any trap on ERR inherited by shell funcs, command substitutions and commands executed in a subshell environment
 set -eE
 
 if [ "$GPGPUSIM_SETUP_ENVIRONMENT_WAS_RUN" != "1" ]; then
@@ -65,10 +33,8 @@ echo "doing: export -n PTX_SIM_USE_PTX_FILE"
 export -n PTX_SIM_USE_PTX_FILE
 echo "doing: export LD_LIBRARY_PATH=REPLACE_LIBPATH:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH=REPLACE_LIBPATH:$LD_LIBRARY_PATH
-# Copy NFS workdir contents (configs, symlinks, etc.) into tmp, then cd there
-rsync -a "$NFS_DIR/" "$TMP_DIR/"
-echo "doing: cd $TMP_DIR (local tmp, NFS dir: $NFS_DIR)"
-cd "$TMP_DIR"
+echo "doing: cd REPLACE_SUBDIR"
+cd REPLACE_SUBDIR
 echo "doing: export OPENCL_CURRENT_TEST_PATH=REPLACE_SUBDIR"
 export OPENCL_CURRENT_TEST_PATH=REPLACE_SUBDIR
 echo "doing: export OPENCL_REMOTE_GPU_HOST=REPLACE_REMOTE_HOST"
@@ -86,3 +52,4 @@ export CUDA_LAUNCH_BLOCKING=1
 
 echo "doing: REPLACE_EXEC_NAME REPLACE_COMMAND_LINE"
 REPLACE_EXEC_NAME REPLACE_COMMAND_LINE
+copy_output


### PR DESCRIPTION
## Problem

The Accel-Sim 2.0 merge (#553) rewrote `util/job_launching/slurm.sim` to stage the working directory in `/tmp` and `rsync` it back to NFS. That template is now hard-bound to a real Slurm + NFS cluster, but it is *also* the template used by the **local** launcher:

```python
elif options.launcher == "local":
    job_submit_call = os.path.join(this_directory, "procman.py")
    job_template = "slurm.sim"
```

`procman.py` provides no `$SLURM_JOB_ID`, and a CI container has neither `squeue` nor (necessarily) `rsync`. Three things then go wrong at once:

1. **`#SBATCH --output=/dev/null` / `--error=/dev/null`** — `procman.py` parses exactly these lines to decide where to write a job's stdout/stderr:
   ```python
   outFMatch = re.match(r"#SBATCH --output=(.*)", line.strip())
   if outFMatch: job.outF = outFMatch.group(1)
   ```
   So every byte the simulator prints is now discarded, leaving no diagnostics at all.

2. **The watchdog self-destructs.** `while squeue -j $SLURM_JOB_ID &>/dev/null; do ... done` returns 127 immediately when `squeue` is absent, so the subshell falls straight through to `sync_to_nfs && rm -rf "$TMP_DIR"` at t≈0 — deleting the staging directory while the main script is still racing to `rsync` into it and `cd` there. With `set -eE` and `trap copy_output EXIT`, the job dies before the simulator produces anything.

3. **`${SLURM_JOB_ID}` is not substituted.** `procman.py` does `re.sub(r"\$SLURM_JOB_ID", str(job.id), line)`, which matches the bare form on the `exec >` and `squeue` lines but *not* the braced form on `TMP_DIR=/tmp/${SLURM_JOB_ID}_REPLACE_NAME`. The staging directory and the log file inside it end up disagreeing about the job id.

Net effect: no `<name>.o<jobid>` ever lands in the run directory, so `job_status.py` reports `NOT_RUNNING_NO_OUTPUT` for every job, within seconds.

## Impact

This is what is currently breaking gpgpu-sim CI, which clones this repo unpinned and launches with `-l local`. Every matrix entry — QV100, TITANV, TITANV-LOCALXBAR, RTX2060, RTX3070, H100 — fails identically on all 10 `rodinia_2.0-ft` apps, with zero output to diagnose from. Last green run was before #553 landed; everything after it fails.

## Fix

Revert `slurm.sim` to the pre-2.0 template. It only needs coreutils `mv`, so it works under both `sbatch` and `procman`.

Follow-up (not in this PR): the tmp-staging behaviour is genuinely useful on the Slurm runners and can be reintroduced guarded on `[ -n "$SLURM_JOB_ID" ]` plus `command -v squeue rsync`, keeping `#SBATCH --output=`/`--error=` pointed at real paths so `procman.py` keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)